### PR TITLE
Return an error on scale when cluster does not exist

### DIFF
--- a/pkg/cmd/cli/cmd/clusters.go
+++ b/pkg/cmd/cli/cmd/clusters.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strconv"
-
+	"github.com/openshift/origin/pkg/client"
 	kapi "k8s.io/kubernetes/pkg/api"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
@@ -115,4 +115,24 @@ func getReplController(client kclient.ReplicationControllerInterface, clusternam
 		}
 	}
 	return &newestRepl, err
+}
+
+func checkForDeploymentConfigs(client client.DeploymentConfigInterface, clustername string) (bool, error) {
+	selectorlist := makeSelector(masterType, clustername)
+	dcs, err := client.List(selectorlist)
+	if err != nil {
+		return false, err
+	}
+	if len(dcs.Items) == 0 {
+		return false, nil
+	}
+	selectorlist = makeSelector(workerType, clustername)
+	dcs, err = client.List(selectorlist)
+	if err != nil {
+		return false, err
+	}
+	if len(dcs.Items) == 0 {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/cmd/cli/cmd/scale.go
+++ b/pkg/cmd/cli/cmd/scale.go
@@ -46,6 +46,14 @@ func CmdScale(f *clientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Comm
 func (o *CmdOptions) RunScale() error {
 	allErrs := []error{}
 
+	ok, err := checkForDeploymentConfigs(o.Client.DeploymentConfigs(o.Project), o.Name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("No such cluster " + o.Name)
+	}
+
 	rcc := o.KClient.ReplicationControllers(o.Project)
 	wrepl, err := getReplController(rcc, o.Name, workerType)
 	if err != nil || wrepl == nil {


### PR DESCRIPTION
Use the presence of the dcs as the indicator that
a cluster exists.