### PR TITLE
Add a build for an extended utility client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ LOCAL_IMAGE=project/oshinko-cli
 build:
 	scripts/build.sh build
 
+extended:
+	scripts/build.sh extended
+
 image:
 	sudo docker build -t $(LOCAL_IMAGE) .
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -41,7 +41,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	}
 
 	f := clientcmd.New(cmds.PersistentFlags())
-	groups := GetCommandGroups(fullName, f, in, out)
+	groups, firstcmd := GetCommandGroups(fullName, f, in, out)
 	groups.Add(cmds)
 	changeSharedFlagDefaults(cmds)
 
@@ -50,7 +50,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	}
 
 	templates.ActsAsRootCommand(cmds, filters, groups...).
-		ExposeFlags(groups[0].Commands[0], "server", "client-certificate",
+		ExposeFlags(firstcmd, "server", "client-certificate",
 		"client-key", "certificate-authority", "insecure-skip-tls-verify", "token")
 
 	cmds.AddCommand(NewCmdOptions(out))

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	oshinkocmd "github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/cmd"
 )
 
 const productName = `Oshinko`
@@ -43,19 +41,7 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	}
 
 	f := clientcmd.New(cmds.PersistentFlags())
-
-	getCmd := oshinkocmd.NewCmdGet(fullName, f, in, out)
-	groups := templates.CommandGroups{
-		{
-			Message: "Basic Commands:",
-			Commands: []*cobra.Command{
-				getCmd,
-				oshinkocmd.NewCmdDelete(fullName, f, in, out),
-				oshinkocmd.NewCmdCreate(fullName, f, in, out),
-				oshinkocmd.NewCmdScale(fullName, f, in, out),
-			},
-		},
-	}
+	groups := GetCommandGroups(fullName, f, in, out)
 	groups.Add(cmds)
 	changeSharedFlagDefaults(cmds)
 
@@ -64,8 +50,8 @@ func NewCommandCLI(name, fullName string, in io.Reader, out, errout io.Writer) *
 	}
 
 	templates.ActsAsRootCommand(cmds, filters, groups...).
-		ExposeFlags(getCmd, "server", "client-certificate",
-			"client-key", "certificate-authority", "insecure-skip-tls-verify", "token")
+		ExposeFlags(groups[0].Commands[0], "server", "client-certificate",
+		"client-key", "certificate-authority", "insecure-skip-tls-verify", "token")
 
 	cmds.AddCommand(NewCmdOptions(out))
 	return cmds

--- a/pkg/cmd/cli/cmd/configmap.go
+++ b/pkg/cmd/cli/cmd/configmap.go
@@ -1,0 +1,53 @@
+// +build extended
+
+package cmd
+
+import (
+	"io"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/auth"
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func NewCmdConfigMap(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) *cobra.Command {
+	cmd := CmdConfigMap(f, in, out)
+	return cmd
+}
+
+func CmdConfigMap(f *clientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Command {
+	authOptions := &auth.AuthOptions{
+		Reader: reader,
+		Out:    out,
+	}
+	options := &CmdOptions{
+		AuthOptions: *authOptions,
+	}
+
+	cmd := &cobra.Command{
+		Use: "configmap <NAME> ",
+		Short: "Return a configmap in json",
+		Long:  "Lookup a configmap by name and print as json if it exists",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := options.Complete(f, cmd, args); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
+			}
+			if err := options.RunCmdConfigMap(out, cmd, args); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+		},
+	}
+	cmd.Flags().StringP("output", "o", "json", "Output format. One of: json|yaml")
+	return cmd
+}
+
+func (o *CmdOptions) RunCmdConfigMap(out io.Writer, cmd *cobra.Command, args []string) error {
+
+	cmap, err := o.KClient.ConfigMaps(o.Project).Get(o.Name)
+	if err != nil {
+		return err
+	}
+	PrintOutput(o.Output, cmap)
+	return nil
+}

--- a/pkg/cmd/cli/cmd/utils.go
+++ b/pkg/cmd/cli/cmd/utils.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"github.com/radanalyticsio/oshinko-core/clusters"
 )
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
@@ -32,9 +31,9 @@ func prettyprint(b []byte) ([]byte, error) {
 	return out.Bytes(), err
 }
 
-func PrintOutput(format string, clusters []clusters.SparkCluster) error {
+func PrintOutput(format string, object interface{}) error {
 	var msg string
-	tmpCluster := clusters
+	tmpCluster := object
 	if format == "yaml" {
 		y, err := yaml.Marshal(tmpCluster)
 		if err != nil {

--- a/pkg/cmd/cli/extended.go
+++ b/pkg/cmd/cli/extended.go
@@ -1,0 +1,32 @@
+// +build extended
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"io"
+
+	oshinkocmd "github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/cmd"
+)
+
+func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) templates.CommandGroups {
+	return templates.CommandGroups{
+		{
+			Message: "Basic Commands:",
+			Commands: []*cobra.Command{
+				oshinkocmd.NewCmdGet(fullName, f, in, out),
+				oshinkocmd.NewCmdDelete(fullName, f, in, out),
+				oshinkocmd.NewCmdCreate(fullName, f, in, out),
+				oshinkocmd.NewCmdScale(fullName, f, in, out),
+			},
+		},
+		{
+			Message: "Extended Commands:",
+			Commands: []*cobra.Command{
+				oshinkocmd.NewCmdConfigMap(fullName, f, in, out),
+			},
+		},
+	}
+}

--- a/pkg/cmd/cli/extended.go
+++ b/pkg/cmd/cli/extended.go
@@ -11,12 +11,15 @@ import (
 	oshinkocmd "github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/cmd"
 )
 
-func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) templates.CommandGroups {
+func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) (
+											templates.CommandGroups,
+											*cobra.Command) {
+	first := oshinkocmd.NewCmdGet(fullName, f, in, out)
 	return templates.CommandGroups{
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				oshinkocmd.NewCmdGet(fullName, f, in, out),
+				first,
 				oshinkocmd.NewCmdDelete(fullName, f, in, out),
 				oshinkocmd.NewCmdCreate(fullName, f, in, out),
 				oshinkocmd.NewCmdScale(fullName, f, in, out),
@@ -28,5 +31,5 @@ func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out i
 				oshinkocmd.NewCmdConfigMap(fullName, f, in, out),
 			},
 		},
-	}
+	}, first
 }

--- a/pkg/cmd/cli/standard.go
+++ b/pkg/cmd/cli/standard.go
@@ -1,0 +1,26 @@
+// +build standard
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/openshift/origin/pkg/cmd/templates"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"io"
+
+	oshinkocmd "github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/cmd"
+)
+
+func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) templates.CommandGroups {
+	return templates.CommandGroups{
+		{
+			Message: "Basic Commands:",
+			Commands: []*cobra.Command{
+				oshinkocmd.NewCmdGet(fullName, f, in, out),
+				oshinkocmd.NewCmdDelete(fullName, f, in, out),
+				oshinkocmd.NewCmdCreate(fullName, f, in, out),
+				oshinkocmd.NewCmdScale(fullName, f, in, out),
+			},
+		},
+	}
+}

--- a/pkg/cmd/cli/standard.go
+++ b/pkg/cmd/cli/standard.go
@@ -11,16 +11,19 @@ import (
 	oshinkocmd "github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/cmd"
 )
 
-func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) templates.CommandGroups {
+func GetCommandGroups(fullName string, f *clientcmd.Factory, in io.Reader, out io.Writer) (
+											templates.CommandGroups,
+											*cobra.Command) {
+	first := oshinkocmd.NewCmdGet(fullName, f, in, out)
 	return templates.CommandGroups{
 		{
 			Message: "Basic Commands:",
 			Commands: []*cobra.Command{
-				oshinkocmd.NewCmdGet(fullName, f, in, out),
+				first,
 				oshinkocmd.NewCmdDelete(fullName, f, in, out),
 				oshinkocmd.NewCmdCreate(fullName, f, in, out),
 				oshinkocmd.NewCmdScale(fullName, f, in, out),
 			},
 		},
-	}
+	}, first
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,11 +16,19 @@ TAG="${GIT_TAG}-${GIT_COMMIT}"
 
 APP=oshinko-cli
 
-if [ $1 = build ]; then
+CMD=$1
+if [ $CMD = build ]; then
+   TAGS="-tags standard"
+elif [ $CMD = extended ]; then
+   TAGS="-tags extended"
+   CMD="build"
+fi
+
+if [ $CMD = build ]; then
     OUTPUT_FLAG="-o _output/oshinko-cli"
 fi
 
-if [ $1 = test ]; then
+if [ $CMD = test ]; then
     TARGET=./tests
     GO_OPTIONS=-v
 else
@@ -28,7 +36,7 @@ else
 fi
 
 #-instrument "$PROJECT/pkg/cmd/cli/cmd,$PROJECT/pkg/cmd/cli/cluster,$PROJECT/pkg/cmd/cli"
-if [ $1 = debug ]; then
+if [ $CMD = debug ]; then
     godebug build  -o _output/oshinko-cli ./cmd/oshinko
 fi
 
@@ -36,8 +44,8 @@ fi
 # 1.5 is still in use.
 export GO15VENDOREXPERIMENT=1
 
-if [ $1 = build ]; then
-    go $1 $GO_OPTIONS -ldflags \
+if [ $CMD = build ]; then
+    go $CMD $GO_OPTIONS $TAGS -ldflags \
     "-X $PROJECT/version.tag=$TAG -X $PROJECT/version.appName=$APP" \
     $OUTPUT_FLAG $TARGET
 fi


### PR DESCRIPTION
The spark application launch scripts need some additional CLI
commands to build and configure a cluster/dirver, but don't need
to include the entire "oc" client. This change adds a build for an
extended oshinko CLI via golang build constraints.