### PR TITLE
Write path of spark config volume to UPDATE_SPARK_CONF_DIR

### DIFF
--- a/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusters.go
+++ b/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusters.go
@@ -135,7 +135,7 @@ func makeEnvVars(clustername, sparkconfdir string) []kapi.EnvVar {
 	envs = append(envs, kapi.EnvVar{Name: "OSHINKO_REST_HOST", Value: os.Getenv("OSHINKO_REST_SERVICE_HOST")})
 	envs = append(envs, kapi.EnvVar{Name: "OSHINKO_REST_PORT", Value: os.Getenv("OSHINKO_REST_SERVICE_PORT")})
 	if sparkconfdir != "" {
-		envs = append(envs, kapi.EnvVar{Name: "SPARK_CONF_DIR", Value: sparkconfdir})
+		envs = append(envs, kapi.EnvVar{Name: "UPDATE_SPARK_CONF_DIR", Value: sparkconfdir})
 	}
 
 	return envs
@@ -279,8 +279,9 @@ func CreateCluster(clustername, namespace, sparkimage string, config *ClusterCon
 	workercount := int(finalconfig.WorkerCount)
 
 	// Check if finalconfig contains the names of ConfigMaps to use for spark
-	// configuration. If so they must exist, and the SPARK_CONF_DIR env must be
-	// set correctly
+	// configuration. If so they must exist. The ConfigMaps will be mounted
+	// as volumes on spark pods and the path stored in the environment
+	// variable UPDATE_SPARK_CONF_DIR
 	cm := client.ConfigMaps(namespace)
 	if finalconfig.SparkMasterConfig != "" {
 		err := checkForConfigMap(finalconfig.SparkMasterConfig, cm)


### PR DESCRIPTION
Update oshinko-core in the vendor dir:

This change puts the path of the spark config volume in
UPDATE_SPARK_CONF_DIR instead of SPARK_CONF_DIR in spark
cluster pods. This allows the startup script to check for
presence of the directory and handle it rather than
directly changing where spark looks for it's configuration.