### PR TITLE
Pass --image flag value in cluster config object

### DIFF
--- a/pkg/cmd/cli/cmd/create.go
+++ b/pkg/cmd/cli/cmd/create.go
@@ -56,7 +56,7 @@ func CmdCreate(f *clientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Com
 	cmd.Flags().String("masterconfig", "", "ConfigMap name for spark master")
 	cmd.Flags().String("workerconfig", "", "ConfigMap name for spark worker")
 	cmd.Flags().String("storedconfig", "", "ConfigMap name for spark cluster")
-	cmd.Flags().String("image", defaultImage, "spark image to be used.Default value is radanalyticsio/openshift-spark.")
+	cmd.Flags().String("image", "", "spark image to be used. Default image is radanalyticsio/openshift-spark.")
 	//cmd.MarkFlagRequired("workers")
 	return cmd
 }
@@ -67,8 +67,9 @@ func (o *CmdOptions) RunCreate(out io.Writer, cmd *cobra.Command, args []string)
 	config.MasterCount = o.MasterCount
 	config.SparkWorkerConfig = o.WorkerConfig
 	config.SparkMasterConfig = o.MasterConfig
+	config.SparkImage = o.Image
 	config.Name = o.StoredConfig
-	_, err := clusters.CreateCluster(o.Name, o.Project, o.Image, &config, o.Client, o.KClient)
+	_, err := clusters.CreateCluster(o.Name, o.Project, defaultImage, &config, o.Client, o.KClient)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusterconfigs.go
+++ b/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusterconfigs.go
@@ -14,6 +14,7 @@ type ClusterConfig struct {
 	Name string
 	SparkMasterConfig string
 	SparkWorkerConfig string
+	SparkImage string
 }
 
 
@@ -22,7 +23,8 @@ var defaultConfig ClusterConfig = ClusterConfig{
 	                                                        WorkerCount: 1,
 								Name: "default",
 								SparkMasterConfig: "",
-								SparkWorkerConfig: ""}
+								SparkWorkerConfig: "",
+								SparkImage: ""}
 
 const Defaultname = "default"
 const failOnMissing = true
@@ -40,6 +42,9 @@ func GetDefaultConfig() ClusterConfig {
 }
 
 func assignConfig(res *ClusterConfig, src ClusterConfig) {
+        if src.Name != "" {
+		res.Name = src.Name
+        }
 	if src.MasterCount != 0 {
 		res.MasterCount = src.MasterCount
 	}
@@ -52,6 +57,9 @@ func assignConfig(res *ClusterConfig, src ClusterConfig) {
 	}
 	if src.SparkWorkerConfig != "" {
 		res.SparkWorkerConfig = src.SparkWorkerConfig
+	}
+	if src.SparkImage != "" {
+		res.SparkImage = src.SparkImage
 	}
 }
 
@@ -90,6 +98,8 @@ func process(config *ClusterConfig, name, value, configmapname string) error {
                 config.SparkMasterConfig = strings.Trim(value, "\n")
 	case "sparkworkerconfig":
                 config.SparkWorkerConfig = strings.Trim(value, "\n")
+	case "sparkimage":
+		config.SparkImage = strings.Trim(value, "\n")
 	}
 	return err
 }

--- a/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusters.go
+++ b/vendor/github.com/radanalyticsio/oshinko-core/clusters/clusters.go
@@ -30,6 +30,7 @@ const mastermsg = "unable to find spark masters"
 const updateReplMsg = "unable to update replication controller for spark workers"
 const noSuchClusterMsg = "no such cluster '%s'"
 const podListMsg = "unable to retrive pod list"
+const sparkImageMsg = "no spark image specified"
 
 const typeLabel = "oshinko-type"
 const clusterLabel = "oshinko-cluster"
@@ -276,6 +277,12 @@ func CreateCluster(clustername, namespace, sparkimage string, config *ClusterCon
 	if err != nil {
 		return result, generalErr(err, clusterConfigMsg, ErrorCode(err))
 	}
+	if finalconfig.SparkImage != "" {
+		sparkimage = finalconfig.SparkImage
+	} else if sparkimage == "" {
+		return result, generalErr(nil, sparkImageMsg, ClusterConfigCode)
+	}
+
 	workercount := int(finalconfig.WorkerCount)
 
 	// Check if finalconfig contains the names of ConfigMaps to use for spark


### PR DESCRIPTION
This change brings oshinko-cli up to date with changes
in oshinko-core to allow the spark image to be specified in
the cluster config. Oshinko-core now treats the "image"
parameter to create() as a default if a cluster config does not
specify an image value. Consequently, the CLI should pass the
default spark image as the "image" parameter and pass any
value from the '--image' flag in a config object.  This
will result in the --image flag value having the highest precedence,
followed by an image value set in a stored config, followed by the
default spark image set in the CLI.

Updates oshinko-core in the vendor dir:

    Allow spark image to be specified in clusterconfigs

    The create routine already allows the image value to be passed
    in as an argument. Allow the image to be set in a cluster config
    as well, which will take precedence. This

    (commit c3af0d476a5c6592fd54847dd013cd3000cf6745 in oshinko-core)