### PR TITLE
update paths for rest client tests

### DIFF
--- a/rest/tools/oshinko-client-tests.yaml
+++ b/rest/tools/oshinko-client-tests.yaml
@@ -25,7 +25,7 @@ objects:
         ref: ${SOURCE_REF}
       dockerfile: |-
         FROM golang
-        ADD . /go/src/github.com/radanalyticsio/oshinko-cli/rest/
+        ADD . /go/src/github.com/radanalyticsio/oshinko-cli/
         WORKDIR /go/src/github.com/radanalyticsio/oshinko-cli/rest
         RUN chmod a+rwX -R .
         RUN go get gopkg.in/check.v1

--- a/rest/tools/oshinko-test.sh
+++ b/rest/tools/oshinko-test.sh
@@ -116,7 +116,7 @@ case "$REQUESTED_TEST" in
 
         if [ -z "$SOURCE_REPO" ]
         then
-            SOURCE_REPO=https://github.com/radanalyticsio/oshinko-cli/rest
+            SOURCE_REPO=https://github.com/radanalyticsio/oshinko-cli
         fi
 
         if [ -z "$SOURCE_REF" ]


### PR DESCRIPTION
This change updates the paths used by the inline dockerfile and the
oshinko-test.sh script to make sure that the client tests can be run.