### PR TITLE
Fix oshinko-rest version after merge

### DIFF
--- a/rest/tools/common.sh
+++ b/rest/tools/common.sh
@@ -1,7 +1,7 @@
 if [ -n "$OSHINKO_SERVER_TAG" ]
 then
     TAG="$OSHINKO_SERVER_TAG"
-elif [ -d .git ]
+elif [ -d ../.git ]
 then
     GIT_TAG=`git describe --tags --abbrev=0 2> /dev/null | head -n1`
     GIT_COMMIT=`git log -n1 --pretty=format:%h 2> /dev/null`


### PR DESCRIPTION
A path in tools/common.sh needs to be changed after
the merge of oshinko-rest into the rest subdirectory.