### PR TITLE
Add support for the --namespace flag

### DIFF
--- a/pkg/cmd/cli/auth/auth.go
+++ b/pkg/cmd/cli/auth/auth.go
@@ -99,6 +99,11 @@ func (o *AuthOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args 
 	apiVersionString := kcmdutil.GetFlagString(cmd, "api-version")
 	o.APIVersion = unversioned.GroupVersion{}
 
+	namespaceFlag := kcmdutil.GetFlagString(cmd, "namespace")
+	if namespaceFlag != "" {
+		o.Project = namespaceFlag
+	}
+
 	// if the API version isn't explicitly passed, use the API version from the default context (same rules as the server above)
 	if len(apiVersionString) == 0 {
 		if defaultContext, defaultContextExists := o.StartingKubeConfig.Contexts[o.StartingKubeConfig.CurrentContext]; defaultContextExists {
@@ -300,6 +305,9 @@ func (o *AuthOptions) GatherAuthInfo() (string, error) {
 
 func (o *AuthOptions) GatherProjectInfo() (string, error) {
 	var msg string
+	if o.Project != "" {
+		return fmt.Sprintf("Using project %q.\n", o.Project), nil
+	}
 	me, err := o.whoAmI()
 	if err != nil {
 		return "", err

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -18,12 +18,18 @@ os::cmd::expect_success "oc whoami"
 #create
 os::cmd::expect_success "_output/oshinko-cli create abc --workers=1 --token=`oc whoami -t`"
 VERBOSE=true os::cmd::expect_success "_output/oshinko-cli get abc --token=`oc whoami -t` -o json"
+
 #scale
 os::cmd::expect_success "_output/oshinko-cli scale abc --workers=2 --token=`oc whoami -t`"
 os::cmd::try_until_text "_output/oshinko-cli get abc --token=`oc whoami -t` -o json" '"workerCount": 0' 2
+
 #delete
 os::cmd::expect_success "_output/oshinko-cli delete abc --token=`oc whoami -t`"
 os::cmd::expect_failure_and_text "_output/oshinko-cli get abc --token=`oc whoami -t` -o json" "no such cluster 'abc'"
+
+#flags
+os::cmd::expect_failure_and_text "_output/oshinko-cli get --token=`oc whoami -t` --verbose --namespace=bob" "Using project \"bob\""
+os::cmd::expect_success_and_text "_output/oshinko-cli get --token=`oc whoami -t` --verbose" "Using project \"oshinko\""
 
 os::cmd::expect_success "oc project default/127-0-0-1:28443/system:admin"
 os::cmd::expect_success "oc delete ns oshinko"


### PR DESCRIPTION
This is a standard flag but the CLI was not using it. If
this option is passed, the o.Project value will be set
based on the value of this flag instead of from the
list of available projects for the user.