### PR TITLE
Allow creation of clusters with zero masters

### DIFF
--- a/core/clusters/clusterconfigs.go
+++ b/core/clusters/clusterconfigs.go
@@ -29,7 +29,7 @@ var defaultConfig ClusterConfig = ClusterConfig{
 const failOnMissing = true
 const allowMissing = false
 
-const MasterCountMustBeZeroOrOne = "cluster configuration must have a master count between 0 and 1"
+const MasterCountMustBeZeroOrOne = "cluster configuration must have a master count of 0 or 1"
 const WorkerCountMustBeAtLeastZero = "cluster configuration may not have a worker count less than 0"
 const ErrorWhileProcessing = "'%s', %s"
 const NamedConfigDoesNotExist = "named config '%s' does not exist"

--- a/core/clusters/clusterconfigs.go
+++ b/core/clusters/clusterconfigs.go
@@ -29,8 +29,8 @@ var defaultConfig ClusterConfig = ClusterConfig{
 const failOnMissing = true
 const allowMissing = false
 
-const MasterCountMustBeOne = "cluster configuration must have a masterCount of 1"
-const WorkerCountMustBeAtLeastZero = "cluster configuration may not have a workerCount less than 0"
+const MasterCountMustBeZeroOrOne = "cluster configuration must have a master count between 0 and 1"
+const WorkerCountMustBeAtLeastZero = "cluster configuration may not have a worker count less than 0"
 const ErrorWhileProcessing = "'%s', %s"
 const NamedConfigDoesNotExist = "named config '%s' does not exist"
 
@@ -67,8 +67,8 @@ func assignConfig(res *ClusterConfig, src ClusterConfig) {
 
 func checkConfiguration(config ClusterConfig) error {
 	var err error
-	if config.MasterCount != 1 {
-		err = NewClusterError(MasterCountMustBeOne, ClusterConfigCode)
+	if config.MasterCount < 0 || config.MasterCount > 1 {
+		err = NewClusterError(MasterCountMustBeZeroOrOne, ClusterConfigCode)
 	} else if config.WorkerCount < 0 {
 		err = NewClusterError(WorkerCountMustBeAtLeastZero, ClusterConfigCode)
 	}

--- a/core/clusters/clusters.go
+++ b/core/clusters/clusters.go
@@ -67,7 +67,7 @@ type SparkCluster struct {
 	MasterWebURL string `json:"masterWebUrl"`
 	Status       string `json:"status"`
 	WorkerCount  int    `json:"workerCount"`
-	MasterCount  int    `json:"masterCount,omitempty"`
+	MasterCount  int    `json:"masterCount"`
 	Config       ClusterConfig
 	Pods         []SparkPod
 }
@@ -85,15 +85,21 @@ func generalErr(err error, msg string, code int) ClusterError {
 
 func makeSelector(otype string, clustername string) kapi.ListOptions {
 	// Build a selector list based on type and/or cluster name
+	var ot *labels.Requirement
+	var cname *labels.Requirement
 	ls := labels.NewSelector()
-	if otype != "" {
-		ot, _ := labels.NewRequirement(typeLabel, selection.Equals, sets.NewString(otype))
-		ls = ls.Add(*ot)
+	if otype == "" {
+		ot, _ = labels.NewRequirement(typeLabel, selection.Exists, sets.String{})
+	} else {
+		ot, _ = labels.NewRequirement(typeLabel, selection.Equals, sets.NewString(otype))
 	}
-	if clustername != "" {
-		cname, _ := labels.NewRequirement(clusterLabel, selection.Equals, sets.NewString(clustername))
-		ls = ls.Add(*cname)
+	ls = ls.Add(*ot)
+	if clustername == "" {
+		cname, _ = labels.NewRequirement(clusterLabel, selection.Exists, sets.String{})
+	} else {
+		cname, _ = labels.NewRequirement(clusterLabel, selection.Equals, sets.NewString(clustername))
 	}
+	ls = ls.Add(*cname)
 	return kapi.ListOptions{LabelSelector: ls}
 }
 
@@ -242,19 +248,6 @@ func checkForConfigMap(name string, cm kclient.ConfigMapsInterface) error {
 		return generalErr(nil, fmt.Sprintf(missingConfigMsg, name), ClientOperationCode)
 	}
 	return nil
-}
-
-func countWorkers(client kclient.PodInterface, clustername string) (int, *kapi.PodList, error) {
-	// If we are  unable to retrieve a list of worker pods, return -1 for count
-	// This is an error case, differnt from a list of length 0. Let the caller
-	// decide whether to report the error or the -1 count
-	cnt := -1
-	selectorlist := makeSelector(workerType, clustername)
-	pods, err := client.List(selectorlist)
-	if pods != nil {
-		cnt = len(pods.Items)
-	}
-	return cnt, pods, err
 }
 
 // Create a cluster and return the representation
@@ -531,11 +524,12 @@ func FindSingleCluster(name, namespace string, osclient *oclient.Client, client 
 	// TODO (tmckay) we should add the spark master and worker configuration values here.
 	// the most likely thing to do is store them in an annotation
 
+	// TODO (tmckay) we need to figure out how to do desired/actual count like the oc
 	result.Name = name
 	result.Namespace = namespace
 	result.Href = "/clusters/" + clustername
-	result.WorkerCount, _, _ = countWorkers(pc, clustername)
-	result.MasterCount = 1
+	result.WorkerCount = int(wrepl.Status.Replicas)
+	result.MasterCount = int(mrepl.Status.Replicas)
 	result.Config.WorkerCount = int(wrepl.Spec.Replicas)
 	result.Config.MasterCount = int(mrepl.Spec.Replicas)
 	result.MasterURL = retrieveServiceURL(sc, masterType, clustername)
@@ -557,12 +551,13 @@ func FindSingleCluster(name, namespace string, osclient *oclient.Client, client 
 		result.Pods = append(result.Pods, addpod(pods.Items[i]))
 	}
 
-	_, workers, err := countWorkers(pc, clustername)
+	selectorlist = makeSelector(workerType, clustername)
+	pods, err = pc.List(selectorlist)
 	if err != nil {
 		return result, generalErr(err, podListMsg, ClientOperationCode)
 	}
-	for i := range workers.Items {
-		result.Pods = append(result.Pods, addpod(workers.Items[i]))
+	for i := range pods.Items {
+		result.Pods = append(result.Pods, addpod(pods.Items[i]))
 	}
 
 	return result, nil
@@ -572,16 +567,17 @@ func FindSingleCluster(name, namespace string, osclient *oclient.Client, client 
 func FindClusters(namespace string, client *kclient.Client) ([]SparkCluster, error) {
 
 	var result []SparkCluster = []SparkCluster{}
-
+	var mcount, wcount int
 	pc := client.Pods(namespace)
 	sc := client.Services(namespace)
+	rcc := client.ReplicationControllers(namespace)
 
 	// Create a map so that we can track clusters by name while we
 	// find out information about them
 	clist := map[string]*SparkCluster{}
 
-	// Get all of the master pods
-	pods, err := pc.List(makeSelector(masterType, ""))
+	// Get all of the pods
+	pods, err := pc.List(makeSelector("", ""))
 	if err != nil {
 		return result, generalErr(err, mastermsg, ClientOperationCode)
 	}
@@ -600,12 +596,23 @@ func FindClusters(namespace string, client *kclient.Client) ([]SparkCluster, err
 			citem.Name = clustername
 			citem.Href = "/clusters/" + clustername
 
-			// Note, we do not report an error here since we are
-			// reporting on multiple clusters. Instead cnt will be -1.
-			cnt, _, _ := countWorkers(pc, clustername)
+			mrepl, err := getReplController(rcc, clustername, masterType)
+			if err == nil && mrepl != nil {
+				mcount = int(mrepl.Status.Replicas)
+			} else {
+				mcount = -1
+			}
+
+			wrepl, err := getReplController(rcc, clustername, workerType)
+			if err == nil && mrepl != nil {
+				wcount = int(wrepl.Status.Replicas)
+			} else {
+				wcount = -1
+			}
 
 			// TODO we only want to count running pods (not terminating)
-			citem.WorkerCount = cnt
+			citem.MasterCount = mcount
+			citem.WorkerCount = wcount
 			citem.MasterURL = retrieveServiceURL(sc, masterType, clustername)
 			citem.MasterWebURL = retrieveServiceURL(sc, webuiType, clustername)
 

--- a/rest/tests/unit/clusterconfigs_test.go
+++ b/rest/tests/unit/clusterconfigs_test.go
@@ -303,7 +303,7 @@ func (s *OshinkoUnitTestSuite) TestGetClusterBadConfig(c *check.C) {
 	c.Assert(myconfig.WorkerCount, check.Equals, defconfig.WorkerCount)
 	c.Assert(brokenMaster.MasterCount, check.Not(check.Equals), 1)
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, clusters.MasterCountMustBeOne)
+	c.Assert(err.Error(), check.Equals, clusters.MasterCountMustBeZeroOrOne)
 }
 
 func (s *OshinkoUnitTestSuite) TestGetClusterNoConfig(c *check.C) {

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -21,7 +21,7 @@ VERBOSE=true os::cmd::expect_success "_output/oshinko-cli get abc --token=`oc wh
 
 #scale
 os::cmd::expect_success_and_text "_output/oshinko-cli scale abc --token=`oc whoami -t`" "neither masters nor workers specified, cluster \"abc\" not scaled"
-os::cmd::expect_failure_and_text "_output/oshinko-cli scale abc --masters=2 --token=`oc whoami -t`" "cluster configuration must have a master count between 0 and 1"
+os::cmd::expect_failure_and_text "_output/oshinko-cli scale abc --masters=2 --token=`oc whoami -t`" "cluster configuration must have a master count of 0 or 1"
 os::cmd::expect_success "_output/oshinko-cli scale abc --workers=0 --masters=0 --token=`oc whoami -t`"
 os::cmd::expect_success "_output/oshinko-cli scale abc --workers=2 --token=`oc whoami -t`"
 os::cmd::try_until_text "_output/oshinko-cli get abc --token=`oc whoami -t` -o json" '"workerCount": 0' 2

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -21,7 +21,7 @@ VERBOSE=true os::cmd::expect_success "_output/oshinko-cli get abc --token=`oc wh
 
 #scale
 os::cmd::expect_success_and_text "_output/oshinko-cli scale abc --token=`oc whoami -t`" "neither masters nor workers specified, cluster \"abc\" not scaled"
-os::cmd::expect_failure_and_text "_output/oshinko-cli scale abc --masters=2 --token=`oc whoami -t`" "cluster configuration must have a masterCount of 1"
+os::cmd::expect_failure_and_text "_output/oshinko-cli scale abc --masters=2 --token=`oc whoami -t`" "cluster configuration must have a master count between 0 and 1"
 os::cmd::expect_success "_output/oshinko-cli scale abc --workers=0 --masters=0 --token=`oc whoami -t`"
 os::cmd::expect_success "_output/oshinko-cli scale abc --workers=2 --token=`oc whoami -t`"
 os::cmd::try_until_text "_output/oshinko-cli get abc --token=`oc whoami -t` -o json" '"workerCount": 0' 2


### PR DESCRIPTION
This change is related to recent changes which allow scaling
masters and workers to zero. Creation needs consistency, and
bugs prevented a cluster with master count of zero. Note that
in a cluster created without a master, the workers will loop
forever waiting for the master to be available (ie if/when the
master count is scaled to 1)