### PR TITLE
Changes around --app flag handling

### DIFF
--- a/core/clusters/clusters.go
+++ b/core/clusters/clusters.go
@@ -534,8 +534,16 @@ func DeleteCluster(clustername, namespace string, osclient *oclient.Client, clie
 			// fall through and cleanup
 			delete = true
 		} else if ephemeral, ok := master.Labels[ephemeralLabel]; ok {
-			deployment := getDriverDeployment(app, namespace, client)
-			if deployment == "" || deployment != ephemeral {
+			var deployment string
+			// If app equals ephemeral then we were passed the name of
+			// the deployment that created the cluster, skip the lookup.
+			// It might even be gone if this delete is triggered by a dc delete!
+			if app == ephemeral {
+				deployment = app
+			} else {
+				deployment = getDriverDeployment(app, namespace, client)
+			}
+			if deployment != ephemeral {
 				info = append(info, "deployment is (" + deployment + ")" )
 				info = append(info, "ephemeral is (" + ephemeral + ")" )
 				info = append(info, "cluster is not linked to app")

--- a/core/clusters/clusters.go
+++ b/core/clusters/clusters.go
@@ -536,6 +536,8 @@ func DeleteCluster(clustername, namespace string, osclient *oclient.Client, clie
 		} else if ephemeral, ok := master.Labels[ephemeralLabel]; ok {
 			deployment := getDriverDeployment(app, namespace, client)
 			if deployment == "" || deployment != ephemeral {
+				info = append(info, "deployment is (" + deployment + ")" )
+				info = append(info, "ephemeral is (" + ephemeral + ")" )
 				info = append(info, "cluster is not linked to app")
 			} else {
 				// If the driver has been scaled to zero, or if the application

--- a/core/clusters/clusters.go
+++ b/core/clusters/clusters.go
@@ -535,7 +535,7 @@ func DeleteCluster(clustername, namespace string, osclient *oclient.Client, clie
 			delete = true
 		} else if ephemeral, ok := master.Labels[ephemeralLabel]; ok {
 			deployment := getDriverDeployment(app, namespace, client)
-			if deployment != ephemeral {
+			if deployment == "" || deployment != ephemeral {
 				info = append(info, "cluster is not linked to app")
 			} else {
 				// If the driver has been scaled to zero, or if the application
@@ -556,6 +556,12 @@ func DeleteCluster(clustername, namespace string, osclient *oclient.Client, clie
 		if !delete {
 			return strings.Join(info, ", "), generalErr(nil, fmt.Sprintf(ephemeralDelMsg, clustername), EphemeralCode)
 		}
+	} else if appstatus != "" {
+		info = append(info, "invalid value for 'appstatus'")
+		return strings.Join(info, ", "), generalErr(nil, fmt.Sprintf(ephemeralDelMsg, clustername), EphemeralCode)
+	} else if app != "" {
+		info = append(info, "specified a value for 'app' but missing 'appstatus'")
+		return strings.Join(info, ", "), generalErr(nil, fmt.Sprintf(ephemeralDelMsg, clustername), EphemeralCode)
 	}
 
 	// Build a selector list for the "oshinko-cluster" label

--- a/pkg/cmd/cli/cmd/cmd.go
+++ b/pkg/cmd/cli/cmd/cmd.go
@@ -89,9 +89,6 @@ func (o *CmdOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args [
 
 	if cmd.Flags().Lookup("ephemeral") != nil {
 		o.Ephemeral = kcmdutil.GetFlagBool(cmd, "ephemeral")
-		if o.Ephemeral && o.App == "" {
-			return cmdutil.UsageError(cmd, "An app value must be supplied if ephemeral is used")
-		}
 	}
 	return nil
 }

--- a/pkg/cmd/cli/cmd/delete.go
+++ b/pkg/cmd/cli/cmd/delete.go
@@ -50,8 +50,7 @@ func CmdDelete(f *clientcmd.Factory, reader io.Reader, out io.Writer, extended b
 }
 
 func (o *CmdOptions) RunDelete(out io.Writer, cmd *cobra.Command, args []string) error {
-
-	if (o.App == "" || o.AppStatus == "") && o.App + o.AppStatus != "" {
+	if o.App != "" && o.AppStatus == "" {
 		return fmt.Errorf("Both --app and --appstatus must be set")
 	}
 	info, err := clusters.DeleteCluster(o.Name, o.Project, o.Client, o.KClient, o.App, o.AppStatus)


### PR DESCRIPTION
Loosen restrictions on --app flag values in CLI and move checking to oshinko-core. This helps in s2i scenarios where a template has not set DEPLOYMENT via the downward api (a shared cluster is always created).