### PR TITLE
Set the default spark image to be set at build time

### DIFF
--- a/pkg/cmd/cli/cmd/cmd.go
+++ b/pkg/cmd/cli/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/radanalyticsio/oshinko-cli/version"
 )
 
 type CmdOptions struct {
@@ -29,7 +30,7 @@ type CmdOptions struct {
 }
 
 func (o *CmdOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args []string) error {
-	o.Image = defaultImage
+	o.Image = version.GetSparkImage()
 
 	// Pod counts will be assigned by the default config in oshinko-core,
 	// here values should be defaulted to the sentinel value

--- a/pkg/cmd/cli/cmd/constants.go
+++ b/pkg/cmd/cli/cmd/constants.go
@@ -4,9 +4,6 @@ const (
 	ScaleCmdUsage   = "scale <NAME>"
 	ScaleCmdShort   = "Scale spark cluster by name"
 	clustersExample = `  # Display the spark cluster %[1]s`
-
-	defaultImage = "radanalyticsio/openshift-spark"
-
 	clustersLong = `
 
 Display information about the spark clusters on the server.`

--- a/pkg/cmd/cli/cmd/create.go
+++ b/pkg/cmd/cli/cmd/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/radanalyticsio/oshinko-cli/core/clusters"
 	"github.com/radanalyticsio/oshinko-cli/pkg/cmd/cli/auth"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"github.com/radanalyticsio/oshinko-cli/version"
 )
 
 var (
@@ -72,7 +73,7 @@ func CmdCreate(f *clientcmd.Factory, reader io.Reader, out io.Writer, extended b
 	cmd.Flags().String("masterconfig", "", "ConfigMap name for spark master")
 	cmd.Flags().String("workerconfig", "", "ConfigMap name for spark worker")
 	cmd.Flags().String("storedconfig", "", "ConfigMap name for spark cluster")
-	cmd.Flags().String("image", "", "spark image to be used. Default image is radanalyticsio/openshift-spark.")
+	cmd.Flags().String("image", "", "spark image to be used. Default image is " + version.GetSparkImage() + ".")
 	cmd.Flags().Bool("exposeui", true, "True will expose the Spark WebUI via a route")
 	if extended {
 		cmd.Flags().BoolP("ephemeral", "e", false, "Treat the cluster as ephemeral. The 'app' flag must also be set.")
@@ -90,7 +91,7 @@ func (o *CmdOptions) RunCreate(out io.Writer, cmd *cobra.Command, args []string)
 	config.SparkImage = o.Image
 	config.Name = o.StoredConfig
 	config.ExposeWebUI = o.ExposeWebUI
-	result, err := clusters.CreateCluster(o.Name, o.Project, defaultImage, &config, o.Client, o.KClient, o.App, o.Ephemeral)
+	result, err := clusters.CreateCluster(o.Name, o.Project, version.GetSparkImage(), &config, o.Client, o.KClient, o.App, o.Ephemeral)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/cmd/version.go
+++ b/pkg/cmd/cli/cmd/version.go
@@ -34,6 +34,6 @@ func CmdVersion(f *clientcmd.Factory, reader io.Reader, out io.Writer) *cobra.Co
 
 func (o *CmdOptions) RunVersion(out io.Writer, cmd *cobra.Command, args []string) error {
 
-	fmt.Fprintf(out, "%s %s\n", version.GetAppName(), version.GetVersion())
+	fmt.Fprintf(out, "%s %s\nDefault spark image: %s\n", version.GetAppName(), version.GetVersion(), version.GetSparkImage())
 	return nil
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -ex
+SPARK_IMAGE="radanalyticsio/openshift-spark:2.1-latest"
 
 go get github.com/renstrom/dedent
 go get github.com/docker/go-connections/nat
@@ -28,7 +29,7 @@ TARGET=./cmd/oshinko
 export GO15VENDOREXPERIMENT=1
 if [ $CMD = build ]; then
     go build $GO_OPTIONS -ldflags \
-    "-X $PROJECT/version.gitTag=$TAG -X $PROJECT/version.appName=$APP" \
+    "-X $PROJECT/version.gitTag=$TAG -X $PROJECT/version.appName=$APP -X $PROJECT/version.sparkImage=$SPARK_IMAGE"\
     -o $OUTPUT_PATH $TARGET
     if [ "$?" -eq 0 ]; then
        rm $OUTPUT_DIR/oshinko-cli || true

--- a/test/cmd/help.sh
+++ b/test/cmd/help.sh
@@ -20,4 +20,7 @@ os::cmd::expect_success_and_text '_output/oshinko help delete_eph' 'Delete spark
 os::cmd::expect_success_and_text '_output/oshinko help get_eph' 'Get running spark clusters'
 os::cmd::expect_success_and_text '_output/oshinko help configmap' 'Lookup a configmap by name and print as json if it exists'
 
+SPARK_IMAGE=$(grep -m 1 SPARK_IMAGE= $(dirname "${BASH_SOURCE}")/../../scripts/build.sh | cut -d '=' -f 2 | sed 's/"//g')
+os::cmd::expect_success '_output/oshinko help create | grep Default\ image\ is\ "$SPARK_IMAGE"'
+
 os::test::junit::declare_suite_end

--- a/test/cmd/version.sh
+++ b/test/cmd/version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+trap os::test::junit::reconcile_output EXIT
+
+os::test::junit::declare_suite_start "cmd/version"
+
+os::cmd::expect_success_and_text "_output/oshinko version" "oshinko"
+
+SPARK_IMAGE=$(grep -m 1 SPARK_IMAGE= $(dirname "${BASH_SOURCE}")/../../scripts/build.sh | cut -d '=' -f 2 | sed 's/"//g')
+os::cmd::expect_success '_output/oshinko version | grep Default\ spark\ image:\ "$SPARK_IMAGE"'
+
+os::test::junit::declare_suite_end

--- a/version/spark.go
+++ b/version/spark.go
@@ -1,0 +1,10 @@
+package version
+
+import (
+)
+
+var sparkImage string
+
+func GetSparkImage() string {
+return sparkImage
+}


### PR DESCRIPTION
This change allows the default spark image to be set in the build
script. This means that specific releases will be able to vary
the default spark image, and the spark version can be listed
in the release notes.