### PR TITLE
Update HACKING doc and include a script to generate release templates

### DIFF
--- a/rest/HACKING.md
+++ b/rest/HACKING.md
@@ -45,7 +45,7 @@ oshinko release. If you want to create a server-ui-template.yaml that uses
 images from a particular release, you can run the `release-templates.sh` script
 to create it. For example:
 
-    $ ./release-templates.sh v0.2.6
+    $ ./tools/release-templates.sh v0.2.6
     Successfully wrote templates to release_templates/ with version tag v0.2.6
 
     grep radanalyticsio/oshinko-.*:v0.2.6 *
@@ -53,9 +53,9 @@ to create it. For example:
     value: radanalyticsio/oshinko-rest:v0.2.6
     value: radanalyticsio/oshinko-webui:v0.2.6
 
+The new template will be written to `tools/release_templates/`
 If you are using `oshinko-deploy.sh`, you can specify the new
-`release_templates/server-ui-template.yaml` as the value for
-the `-t` option as described below.
+template as the value for the `-t` option as described below.
 
 ### Checking the default spark image for oshinko-rest and oshinko-web
 

--- a/rest/release-templates.sh
+++ b/rest/release-templates.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: release-templates.sh VERSION-TAG"
+    exit 1
+fi
+
+TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')/rest
+mkdir -p $TOP_DIR/release_templates
+rm -rf $TOP_DIR/release_templates/*
+
+cp $TOP_DIR/tools/server-ui-template.yaml $TOP_DIR/release_templates
+
+sed -r -i "s@(radanalyticsio/oshinko-.*)@\1:$1@" $TOP_DIR/release_templates/*
+
+echo "Successfully wrote templates to release_templates/ with version tag $1"
+echo
+echo "grep radanalyticsio/oshinko-.*:$1 *"
+echo
+cd $TOP_DIR/; grep radanalyticsio/oshinko-.*:$1 release_templates/*

--- a/rest/tools/release-templates.sh
+++ b/rest/tools/release-templates.sh
@@ -5,11 +5,11 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')/rest
+TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')/rest/tools
 mkdir -p $TOP_DIR/release_templates
 rm -rf $TOP_DIR/release_templates/*
 
-cp $TOP_DIR/tools/server-ui-template.yaml $TOP_DIR/release_templates
+cp $TOP_DIR/server-ui-template.yaml $TOP_DIR/release_templates
 
 sed -r -i "s@(radanalyticsio/oshinko-.*)@\1:$1@" $TOP_DIR/release_templates/*
 


### PR DESCRIPTION
This change includes a script to generate a server-ui-template.yaml
that references a particular oshinko release. It also modifies
oshinko-deploy.sh so that default image values in the template
are not overwritten unless specificaly specified.