### PR TITLE
Write cluster config to an annotation on the spark cluster

### DIFF
--- a/core/clusters/clusterconfigs.go
+++ b/core/clusters/clusterconfigs.go
@@ -23,12 +23,12 @@ const Defaultname = "default-oshinko-cluster-config"
 var defaultConfig ClusterConfig = ClusterConfig{
 	MasterCount:       1,
 	WorkerCount:       1,
-	Name:              "default",
+	Name:              "",
 	SparkMasterConfig: "",
 	SparkWorkerConfig: "",
 	SparkImage:        "",
-        ExposeWebUI:       "true",
-	Metrics: 	   "",
+	ExposeWebUI:       "true",
+	Metrics: 	   "false",
 }
 
 const failOnMissing = true

--- a/core/clusters/deploymentconfigs/deploymentconfigs.go
+++ b/core/clusters/deploymentconfigs/deploymentconfigs.go
@@ -29,10 +29,22 @@ func (dc *ODeploymentConfig) Replicas(r int) *ODeploymentConfig {
 }
 
 func (dc *ODeploymentConfig) Label(name, value string) *ODeploymentConfig {
-	if dc.Labels == nil {
-		dc.Labels = map[string]string{}
+	l := dc.GetLabels()
+	if l == nil {
+		l = map[string]string{}
+		dc.SetLabels(l)
 	}
-	dc.Labels[name] = value
+	l[name] = value
+	return dc
+}
+
+func (dc *ODeploymentConfig) Annotate(name, value string) *ODeploymentConfig {
+	a := dc.GetAnnotations()
+	if a == nil {
+		a = map[string]string{}
+		dc.SetAnnotations(a)
+	}
+	a[name] = value
 	return dc
 }
 

--- a/rest/handlers/clusters.go
+++ b/rest/handlers/clusters.go
@@ -199,12 +199,9 @@ func DeleteClusterResponse(params apiclusters.DeleteSingleClusterParams) middlew
 		return reterr(fail(err, clientMsg, 500))
 	}
 
-	info, err := coreclusters.DeleteCluster(params.Name, namespace, osclient, client, "", "")
+	_, err = coreclusters.DeleteCluster(params.Name, namespace, osclient, client, "", "")
 	if err != nil {
 		return reterr(fail(err, "", getErrorCode(err)))
-	}
-	if info != "" {
-		return reterr(fail(nil, "deletion may be incomplete: " + info, 500))
 	}
 	return apiclusters.NewDeleteSingleClusterNoContent()
 }

--- a/rest/handlers/clusters.go
+++ b/rest/handlers/clusters.go
@@ -75,7 +75,6 @@ func singleClusterResponse(sc coreclusters.SparkCluster) *models.SingleCluster {
 	cluster.Cluster.MasterURL = tostrptr(sc.MasterURL)
 	cluster.Cluster.MasterWebURL = tostrptr(sc.MasterWebURL)
 	cluster.Cluster.MasterWebRoute = sc.MasterWebRoute
-
 	cluster.Cluster.Status = tostrptr(sc.Status)
 
 	cluster.Cluster.Pods = []*models.ClusterModelPodsItems0{}
@@ -91,6 +90,7 @@ func singleClusterResponse(sc coreclusters.SparkCluster) *models.SingleCluster {
 		Name: sc.Config.Name,
 		ExposeWebUI: sc.Config.ExposeWebUI,
 		Metrics: sc.Config.Metrics,
+		SparkImage: sc.Config.SparkImage,
 	}
 	return cluster
 }

--- a/rest/tests/client/clusters_client_test.go
+++ b/rest/tests/client/clusters_client_test.go
@@ -181,7 +181,11 @@ func (s *OshinkoRestTestSuite) TestCreateAndDeleteCluster(c *check.C) {
 	if err != nil {
 		switch err.(type) {
 		case *clusters.DeleteSingleClusterDefault:
-			c.Fatal(err.(*clusters.DeleteSingleClusterDefault).Error())
+			msg := err.(*clusters.DeleteSingleClusterDefault).Error() + "\n"
+			for _, e := range err.(*clusters.DeleteSingleClusterDefault).Payload.Errors {
+				msg += errors.SingleErrorToString(e)
+			}
+			c.Fatal(msg)
 		default:
 			c.Fatal(err)
 		}

--- a/rest/tests/unit/clusterconfigs_test.go
+++ b/rest/tests/unit/clusterconfigs_test.go
@@ -131,7 +131,7 @@ func (s *OshinkoUnitTestSuite) TestDefaultConfig(c *check.C) {
 	c.Assert(myconfig.SparkMasterConfig, check.Equals, defconfig.SparkMasterConfig)
 	c.Assert(myconfig.SparkWorkerConfig, check.Equals, defconfig.SparkWorkerConfig)
 	c.Assert(myconfig.ExposeWebUI, check.Equals, defconfig.ExposeWebUI)
-	c.Assert(myconfig.Name, check.Equals, "default")
+	c.Assert(myconfig.Name, check.Equals, "")
 	c.Assert(err, check.IsNil)
 
 	// Test that with a config object containing sentinel values, we get the default config
@@ -143,7 +143,7 @@ func (s *OshinkoUnitTestSuite) TestDefaultConfig(c *check.C) {
 	c.Assert(myconfig.WorkerCount, check.Equals, defconfig.WorkerCount)
 	c.Assert(myconfig.SparkMasterConfig, check.Equals, defconfig.SparkMasterConfig)
 	c.Assert(myconfig.SparkWorkerConfig, check.Equals, defconfig.SparkWorkerConfig)
-	c.Assert(myconfig.Name, check.Equals, "default")
+	c.Assert(myconfig.Name, check.Equals, "")
 	c.Assert(err, check.IsNil)
 }
 

--- a/rest/tools/oshinko-test.sh
+++ b/rest/tools/oshinko-test.sh
@@ -171,6 +171,12 @@ case "$REQUESTED_TEST" in
         oc create sa oshinko -n $PROJECT
         oc policy add-role-to-user admin system:serviceaccount:$PROJECT:oshinko -n $PROJECT
 
+        # These empty configmaps are needed for tests that look at reported config
+        # Since they're empty they're not actually used, just reported back in status, this is fine
+        oc create configmap clusterconfig
+        oc create configmap masterconfig
+        oc create configmap workerconfig
+
         oc process -f tools/oshinko-client-tests.yaml \
                    -v SOURCE_REPO=$SOURCE_REPO \
                    -v SOURCE_REF=$SOURCE_REF \

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -10,32 +10,44 @@ os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any proj
 # name required
 os::cmd::expect_failure "_output/oshinko create"
 
+# General note -- at present, the master and worker counts in the included config object on get are "MasterCount" and "WorkerCount"
+# the master and worker counts in the outer cluster status are "masterCount" and "workerCount"
+# Likewise, SparkImage is from config and 'image' is in the outer cluster status
+
 # default one worker / one master
 os::cmd::expect_success "_output/oshinko create abc"
 os::cmd::expect_success "_output/oshinko get abc -o yaml | grep 'WorkerCount: 1'"
 os::cmd::expect_success "_output/oshinko get abc -o yaml | grep 'MasterCount: 1'"
+# could still be creating so use 'until'
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "workerCount: 1"
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "masterCount: 1"
 os::cmd::expect_success "_output/oshinko delete abc"
 
 # workers flag
 os::cmd::expect_success "_output/oshinko create def --workers=-1"
 os::cmd::expect_success "_output/oshinko get def -o yaml | grep 'WorkerCount: 1'"
+os::cmd::try_until_text "_output/oshinko get def -o yaml" "workerCount: 1"
 os::cmd::expect_success "_output/oshinko delete def"
 
 os::cmd::expect_success "_output/oshinko create ghi --workers=2"
 os::cmd::expect_success "_output/oshinko get ghi -o yaml | grep 'WorkerCount: 2'"
+os::cmd::try_until_text "_output/oshinko get ghi -o yaml" "workerCount: 2"
 os::cmd::expect_success "_output/oshinko delete ghi"
 
 os::cmd::expect_success "_output/oshinko create sam --workers=0"
 os::cmd::expect_success "_output/oshinko get sam -o yaml | grep 'WorkerCount: 0'"
+os::cmd::try_until_text "_output/oshinko get sam -o yaml" "workerCount: 0"
 os::cmd::expect_success "_output/oshinko delete sam"
 
 # masters flag
 os::cmd::expect_success "_output/oshinko create jkl --masters=-1"
 os::cmd::expect_success "_output/oshinko get jkl -o yaml | grep 'MasterCount: 1'"
+os::cmd::try_until_text "_output/oshinko get jkl -o yaml" "masterCount: 1"
 os::cmd::expect_success "_output/oshinko delete jkl"
 
 os::cmd::expect_success "_output/oshinko create jill --masters=0"
 os::cmd::expect_success "_output/oshinko get jill -o yaml | grep 'MasterCount: 0'"
+os::cmd::try_until_text "_output/oshinko get jill -o yaml" "masterCount: 0"
 os::cmd::expect_success "_output/oshinko delete jill"
 
 os::cmd::expect_failure_and_text "_output/oshinko create mno --masters=2" "cluster configuration must have a master count of 0 or 1"
@@ -58,46 +70,92 @@ os::cmd::expect_failure_and_text "_output/oshinko create sally" "cluster 'sally'
 # create against incomplete clusters
 os::cmd::expect_success "oc delete service sally-ui"
 os::cmd::expect_failure_and_text "_output/oshinko create sally" "cluster 'sally' already exists \(incomplete\)"
+os::cmd::expect_success "_output/oshinko delete sally"
 
 # metrics
 os::cmd::expect_success "_output/oshinko create klondike --metrics=true"
 os::cmd::try_until_success "oc get service klondike-metrics"
+os::cmd::expect_success "_output/oshinko delete klondike"
 
 os::cmd::expect_success "_output/oshinko create klondike2"
 os::cmd::try_until_success "oc get service klondike2-ui"
 os::cmd::expect_failure "oc get service klondike2-metrics"
+os::cmd::expect_success "_output/oshinko delete klondike2"
 
 os::cmd::expect_success "_output/oshinko create klondike3 --metrics=false"
 os::cmd::try_until_success "oc get service klondike3-ui"
 os::cmd::expect_failure "oc get service klondike3-metrics"
+os::cmd::expect_success "_output/oshinko delete klondike3"
 
 os::cmd::expect_failure_and_text "_output/oshinko create klondike4 --metrics=notgonnadoit" "must be a boolean"
 
 # exposeui
 os::cmd::expect_success "_output/oshinko create charlie --exposeui=false"
 os::cmd::expect_success_and_text "_output/oshinko get charlie" "charlie.*<no route>"
+os::cmd::expect_success "_output/oshinko delete charlie"
 
 os::cmd::expect_success "_output/oshinko create charlie2 --exposeui=true"
 os::cmd::expect_success_and_text "_output/oshinko get charlie2" "charlie2-ui-route"
+os::cmd::expect_success "_output/oshinko delete charlie2"
 
 os::cmd::expect_success "_output/oshinko create charlie3"
 os::cmd::expect_success_and_text "_output/oshinko get charlie3" "charlie3-ui-route"
+os::cmd::expect_success "_output/oshinko delete charlie3"
 
 os::cmd::expect_failure_and_text "_output/oshinko create charlie4 --exposeui=notgonnadoit" "must be a boolean"
 
 # storedconfig
-oc create configmap clusterconfig --from-literal=workercount=3 --from-literal=mastercount=0 
+oc create configmap masterconfig
+oc create configmap workerconfig
+oc create configmap clusterconfig \
+--from-literal=workercount=3 \
+--from-literal=mastercount=0 \
+--from-literal=sparkmasterconfig=masterconfig \
+--from-literal=sparkworkerconfig=workerconfig \
+--from-literal=exposeui=false \
+--from-literal=metrics=true \
+--from-literal=sparkimage=myimage
 os::cmd::expect_failure_and_text "_output/oshinko create chicken --storedconfig=jack" "named config 'jack' does not exist"
 os::cmd::expect_success "_output/oshinko create chicken --storedconfig=clusterconfig"
 os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "WorkerCount: 3"
 os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "MasterCount: 0"
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "ExposeWebUI: \"false\""
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "Metrics: \"true\""
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "Name: clusterconfig"
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "SparkImage: myimage"
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "image: myimage"
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "SparkMasterConfig: masterconfig"
+os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "SparkWorkerConfig: workerconfig"
+os::cmd::try_until_text "_output/oshinko get chicken -o yaml" "workerCount: 3"
+os::cmd::try_until_text "_output/oshinko get chicken -o yaml" "masterCount: 0"
+os::cmd::expect_success "_output/oshinko delete chicken"
+
+os::cmd::expect_success "_output/oshinko create egg"
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "WorkerCount: 1"
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "MasterCount: 1"
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "ExposeWebUI: \"true\""
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "Metrics: \"false\""
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "Name: \"\""
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "SparkImage: radanalyticsio/openshift-spark"
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "image: radanalyticsio/openshift-spark"
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "SparkMasterConfig: \"\""
+os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "SparkWorkerConfig: \"\""
+os::cmd::try_until_text "_output/oshinko get egg -o yaml" "workerCount: 1"
+os::cmd::try_until_text "_output/oshinko get egg -o yaml" "masterCount: 1"
+os::cmd::expect_success "_output/oshinko delete egg"
 
 os::cmd::expect_success "_output/oshinko create hawk --workers=1 --masters=1 --storedconfig=clusterconfig"
 os::cmd::expect_success_and_text "_output/oshinko get hawk -o yaml" "WorkerCount: 1"
 os::cmd::expect_success_and_text "_output/oshinko get hawk -o yaml" "MasterCount: 1"
+os::cmd::try_until_text "_output/oshinko get hawk -o yaml" "workerCount: 1"
+os::cmd::try_until_text "_output/oshinko get hawk -o yaml" "masterCount: 1"
+os::cmd::expect_success "_output/oshinko delete hawk"
 
 # image
 os::cmd::expect_success "_output/oshinko create cordial --image=someotherimage"
+os::cmd::expect_success_and_text "_output/oshinko get cordial -o yaml" "SparkImage: someotherimage"
+os::cmd::expect_success_and_text "_output/oshinko get cordial -o yaml" "image: someotherimage"
+os::cmd::expect_success "_output/oshinko delete cordial"
 
 # flags for ephemeral not valid
 os::cmd::expect_failure_and_text "_output/oshinko create mouse --app=bill" "unknown flag"

--- a/test/cmd/scale.sh
+++ b/test/cmd/scale.sh
@@ -15,6 +15,6 @@ os::cmd::expect_success_and_text "_output/oshinko scale abc" "neither masters no
 os::cmd::expect_failure_and_text "_output/oshinko scale abc --masters=2" "cluster configuration must have a master count of 0 or 1"
 os::cmd::expect_success "_output/oshinko scale abc --workers=0 --masters=0"
 os::cmd::expect_success "_output/oshinko scale abc --workers=2"
-os::cmd::try_until_text "_output/oshinko get abc -o json" '"WorkerCount": 2' 
+os::cmd::try_until_text "_output/oshinko get abc -o json" '"workerCount": 2'
 
 os::test::junit::declare_suite_end

--- a/test/cmd/scale.sh
+++ b/test/cmd/scale.sh
@@ -2,19 +2,63 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
+
+function check_oc_version {
+    vers=$(oc version | grep "oc v" | cut -d' ' -f2- | tr -d v)
+    major=$(echo $vers | cut -d'.' -f1)
+    minor=$(echo $vers | cut -d'.' -f2)
+    if [ $((major)) -lt $1 ]; then
+        return 1
+    fi
+    if [ $((major)) -gt $1 ]; then
+        return 0
+    fi
+    if [ $((minor)) -ge $2 ]; then
+        return 0
+    fi
+    return 1
+}
+
+#set +e
+#check_oc_version 1 5
+#res=$?
+#set -e
+
 os::test::junit::declare_suite_start "cmd/scale"
+
+# General note -- at present, the master and worker counts in the included config object on get are "MasterCount" and "WorkerCount"
+# the master and worker counts in the outer cluster status are "masterCount" and "workerCount"
 
 os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
 
 # make a cluster to scale
-os::cmd::expect_success "_output/oshinko create abc --workers=1"
+os::cmd::expect_success "_output/oshinko create abc"
 os::cmd::try_until_success "_output/oshinko get abc"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "WorkerCount: 1"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "MasterCount: 1"
+# could still be creating so use 'until'
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "workerCount: 1"
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "masterCount: 1"
 
 # scale
 os::cmd::expect_success_and_text "_output/oshinko scale abc" "neither masters nor workers specified, cluster \"abc\" not scaled"
 os::cmd::expect_failure_and_text "_output/oshinko scale abc --masters=2" "cluster configuration must have a master count of 0 or 1"
 os::cmd::expect_success "_output/oshinko scale abc --workers=0 --masters=0"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "WorkerCount: 0"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "MasterCount: 0"
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "workerCount: 0"
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "masterCount: 0"
+
 os::cmd::expect_success "_output/oshinko scale abc --workers=2"
-os::cmd::try_until_text "_output/oshinko get abc -o json" '"workerCount": 2'
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "MasterCount: 0"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o json" '"WorkerCount": 2'
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "workerCount: 2"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "masterCount: 0"
+
+os::cmd::expect_success "_output/oshinko scale abc --masters=1"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "MasterCount: 1"
+os::cmd::expect_success_and_text "_output/oshinko get abc -o json" '"WorkerCount": 2'
+os::cmd::expect_success_and_text "_output/oshinko get abc -o yaml" "workerCount: 2"
+os::cmd::try_until_text "_output/oshinko get abc -o yaml" "masterCount: 1"
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
This change records the spark cluster configuration in an annotation on the spark master deploymentconfig so that complete configuration info can be retrieved on a "get" operation.  The annotation preserves info that cannot be reconstructed easily or at all.   The scale/update operations also modify the annotation to keep it current.