### PR TITLE
Support 'prometheus' as a value for --metrics

### DIFF
--- a/pkg/cmd/cli/cmd/cmd.go
+++ b/pkg/cmd/cli/cmd/cmd.go
@@ -91,8 +91,8 @@ func (o *CmdOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args [
 		o.Metrics = kcmdutil.GetFlagString(cmd, "metrics")
 		if o.Metrics != "" {
 			_, err := strconv.ParseBool(o.Metrics)
-			if err != nil {
-				return cmdutil.UsageError(cmd, "Value for 'metrics' must be a boolean")
+			if err != nil && o.Metrics != "jolokia" && o.Metrics != "prometheus" {
+				return cmdutil.UsageError(cmd, "Value for 'metrics' must be 'true', 'false', 'jolokia', or 'prometheus'")
 			}
 		}
 	}

--- a/pkg/cmd/cli/cmd/create.go
+++ b/pkg/cmd/cli/cmd/create.go
@@ -75,7 +75,7 @@ func CmdCreate(f *clientcmd.Factory, reader io.Reader, out io.Writer, extended b
 	cmd.Flags().String("storedconfig", "", "ConfigMap name for spark cluster")
 	cmd.Flags().String("image", "", "Spark image to be used. Default image is " + version.GetSparkImage() + ".")
 	cmd.Flags().String("exposeui", "", "True or False, expose the Spark WebUI via a route (default True)")
-	cmd.Flags().String("metrics", "", "True or False, enable spark metrics (default False)")
+	cmd.Flags().String("metrics", "", "Enable spark metrics (default false). Set the value to 'prometheus' for prometheus metrics and 'true' or 'jolokia' for jolokia metrics (deprecated).")
 	if extended {
 		cmd.Flags().BoolP("ephemeral", "e", false, "Treat the cluster as ephemeral. The 'app' flag must also be set.")
 		cmd.Flags().String("app", "", "Associate the cluster with an app.  Value may be the name of a pod or deployment (but not a deploymentconfig)")

--- a/rest/tests/unit/clusterconfigs_test.go
+++ b/rest/tests/unit/clusterconfigs_test.go
@@ -344,7 +344,7 @@ func (s *OshinkoUnitTestSuite) TestGetClusterNonInts(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals,
 		fmt.Sprintf(clusters.ErrorWhileProcessing,
-			configarg.Name + ".mastercount", "expected integer"))
+			configarg.Name + ".mastercount", "expected integer, got 'fish'"))
 
 	w := makeConfigMap(nonIntWorker)
 	w.Data["workercount"] = "dog"
@@ -354,7 +354,7 @@ func (s *OshinkoUnitTestSuite) TestGetClusterNonInts(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Equals,
 		fmt.Sprintf(clusters.ErrorWhileProcessing,
-			configarg.Name + ".workercount", "expected integer"))
+			configarg.Name + ".workercount", "expected integer, got 'dog'"))
 }
 
 func (s *OshinkoUnitTestSuite) TestGetClusterUserDefault(c *check.C) {

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -75,17 +75,17 @@ os::cmd::expect_success "_output/oshinko delete sally"
 # metrics
 os::cmd::expect_success "_output/oshinko create klondike --metrics=true"
 os::cmd::try_until_success "oc get service klondike-metrics"
-os::cmd::try_until_text "oc log dc/klondike-m" "with.*metrics"
+os::cmd::try_until_text "oc log dc/klondike-m" "with jolokia metrics"
 os::cmd::expect_success "_output/oshinko delete klondike"
 
 os::cmd::expect_success "_output/oshinko create klondike0 --metrics=jolokia"
 os::cmd::try_until_success "oc get service klondike0-metrics"
-os::cmd::try_until_text "oc log dc/klondike0-m" "with.*metrics"
+os::cmd::try_until_text "oc log dc/klondike0-m" "with jolokia metrics"
 os::cmd::expect_success "_output/oshinko delete klondike0"
 
 os::cmd::expect_success "_output/oshinko create klondike1 --metrics=prometheus"
 os::cmd::try_until_success "oc get service klondike1-metrics"
-os::cmd::try_until_text "oc log dc/klondike1-m" "with.*metrics"
+os::cmd::try_until_text "oc log dc/klondike1-m" "with prometheus metrics"
 os::cmd::expect_success "_output/oshinko delete klondike1"
 
 os::cmd::expect_success "_output/oshinko create klondike2"

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -75,7 +75,18 @@ os::cmd::expect_success "_output/oshinko delete sally"
 # metrics
 os::cmd::expect_success "_output/oshinko create klondike --metrics=true"
 os::cmd::try_until_success "oc get service klondike-metrics"
+os::cmd::try_until_text "oc log dc/klondike-m" "with.*metrics"
 os::cmd::expect_success "_output/oshinko delete klondike"
+
+os::cmd::expect_success "_output/oshinko create klondike0 --metrics=jolokia"
+os::cmd::try_until_success "oc get service klondike0-metrics"
+os::cmd::try_until_text "oc log dc/klondike0-m" "with.*metrics"
+os::cmd::expect_success "_output/oshinko delete klondike0"
+
+os::cmd::expect_success "_output/oshinko create klondike1 --metrics=prometheus"
+os::cmd::try_until_success "oc get service klondike1-metrics"
+os::cmd::try_until_text "oc log dc/klondike1-m" "with.*metrics"
+os::cmd::expect_success "_output/oshinko delete klondike1"
 
 os::cmd::expect_success "_output/oshinko create klondike2"
 os::cmd::try_until_success "oc get service klondike2-ui"
@@ -87,7 +98,7 @@ os::cmd::try_until_success "oc get service klondike3-ui"
 os::cmd::expect_failure "oc get service klondike3-metrics"
 os::cmd::expect_success "_output/oshinko delete klondike3"
 
-os::cmd::expect_failure_and_text "_output/oshinko create klondike4 --metrics=notgonnadoit" "must be a boolean"
+os::cmd::expect_failure_and_text "_output/oshinko create klondike4 --metrics=notgonnadoit" "must be 'true', 'false', 'jolokia', or 'prometheus'"
 
 # exposeui
 os::cmd::expect_success "_output/oshinko create charlie --exposeui=false"
@@ -129,6 +140,16 @@ os::cmd::expect_success_and_text "_output/oshinko get chicken -o yaml" "SparkWor
 os::cmd::try_until_text "_output/oshinko get chicken -o yaml" "workerCount: 3"
 os::cmd::try_until_text "_output/oshinko get chicken -o yaml" "masterCount: 0"
 os::cmd::expect_success "_output/oshinko delete chicken"
+
+oc create configmap clusterconfig2 --from-literal=metrics=jolokia
+os::cmd::expect_success "_output/oshinko create chicken2 --storedconfig=clusterconfig2"
+os::cmd::expect_success_and_text "_output/oshinko get chicken2 -o yaml" "Metrics: jolokia"
+os::cmd::expect_success "_output/oshinko delete chicken2"
+
+oc create configmap clusterconfig3 --from-literal=metrics=prometheus
+os::cmd::expect_success "_output/oshinko create chicken3 --storedconfig=clusterconfig3"
+os::cmd::expect_success_and_text "_output/oshinko get chicken3 -o yaml" "Metrics: prometheus"
+os::cmd::expect_success "_output/oshinko delete chicken3"
 
 os::cmd::expect_success "_output/oshinko create egg"
 os::cmd::expect_success_and_text "_output/oshinko get egg -o yaml" "WorkerCount: 1"


### PR DESCRIPTION
This change corresponds to https://github.com/radanalyticsio/openshift-spark/pull/35
It maintains backward compatibility with 'jolokia' as the
default metrics deployment if --metrics is set to 'true' but
also allows the explicit values 'jolokia' and 'prometheus'.
The description also notes that jolokia is deprecated and
prometheus should be used.