### PR TITLE
fixed build.sh for mac

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-set -ex
 if [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
-        if ! [ -x "$(greadlink)" ]; then
-          'Error: coreutils is not installed.' >&2
+	    result=:$(brew ls coreutils)
+        if [ -z "$result" ]; then
+          'Error: coreutils is not installed.'
           exit 1
         fi
         TOP_DIR=$(greadlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')


### PR DESCRIPTION
There was a problem with the previous implementation (by me) in build.sh for the check for coreutils this has now been changed and is working - a new ticket has been added to in review for the issue to be reviewed