### PR TITLE
Modify how name of default cluster config is recorded

### DIFF
--- a/core/clusters/clusterconfigs.go
+++ b/core/clusters/clusterconfigs.go
@@ -199,6 +199,11 @@ func GetClusterConfig(config *ClusterConfig, restconfig *rest.Config, namespace 
 
 	var name string = ""
 	if config != nil {
+		// If the default name is explicitly set, put it back to empty string
+		// We will record default name in the config only if we found an overriding configmap
+		if config.Name == Defaultname {
+			config.Name = ""
+		}
 		name = config.Name
 	}
 	res, err = loadConfig(name, restconfig, namespace)

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -165,6 +165,23 @@ os::cmd::try_until_text "_output/oshinko get egg -o yaml" "workerCount: 1"
 os::cmd::try_until_text "_output/oshinko get egg -o yaml" "masterCount: 1"
 os::cmd::expect_success "_output/oshinko delete egg"
 
+oc create configmap default-oshinko-cluster-config --from-literal=workercount=2
+os::cmd::expect_success "_output/oshinko create readdefault"
+os::cmd::expect_success_and_text "_output/oshinko get readdefault -o yaml" "Name: default-oshinko-cluster-config"
+os::cmd::expect_success_and_text "_output/oshinko get readdefault -o yaml" "WorkerCount: 2"
+os::cmd::expect_success "_output/oshinko delete readdefault"
+
+os::cmd::expect_success "_output/oshinko create readdefault2 --storedconfig=default-oshinko-cluster-config"
+os::cmd::expect_success_and_text "_output/oshinko get readdefault2 -o yaml" "Name: default-oshinko-cluster-config"
+os::cmd::expect_success_and_text "_output/oshinko get readdefault2 -o yaml" "WorkerCount: 2"
+os::cmd::expect_success "_output/oshinko delete readdefault2"
+
+oc delete configmap default-oshinko-cluster-config
+os::cmd::expect_success "_output/oshinko create readdefault3 --storedconfig=default-oshinko-cluster-config"
+os::cmd::expect_success_and_text "_output/oshinko get readdefault3 -o yaml" "Name: \"\""
+os::cmd::expect_success_and_text "_output/oshinko get readdefault3 -o yaml" "WorkerCount: 1"
+os::cmd::expect_success "_output/oshinko delete readdefault3"
+
 os::cmd::expect_success "_output/oshinko create hawk --workers=1 --masters=1 --storedconfig=clusterconfig"
 os::cmd::expect_success_and_text "_output/oshinko get hawk -o yaml" "WorkerCount: 1"
 os::cmd::expect_success_and_text "_output/oshinko get hawk -o yaml" "MasterCount: 1"


### PR DESCRIPTION
If a configmap is created to override the default cluster config,
set the "Name" field of the cluster config to default-oshinko-cluster-config
if the configmap is actually read. Otherwise, if hardcoded defaults are used,
set the "Name" field to empty string.