### PR TITLE
get cli cmd returns headers

### DIFF
--- a/pkg/cmd/cli/cmd/cmd.go
+++ b/pkg/cmd/cli/cmd/cmd.go
@@ -32,6 +32,7 @@ type CmdOptions struct {
 	NoNameRequired bool
 	Metrics        string
 	NoPods         bool
+	Deprecated     bool
 	auth.AuthOptions
 }
 
@@ -130,6 +131,9 @@ func (o *CmdOptions) Complete(f *osclientcmd.Factory, cmd *cobra.Command, args [
 	if cmd.Flags().Lookup("nopods") != nil {
 		o.NoPods = kcmdutil.GetFlagBool(cmd, "nopods")
 	}
+	if cmd.Flags().Lookup("deprecated")!=nil{
+		o.Deprecated = kcmdutil.GetFlagBool(cmd, "deprecated")
+	}
 	return nil
 }
 
@@ -150,3 +154,4 @@ func (o *CmdOptions) GatherInfo() error {
 	}
 	return nil
 }
+

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -57,14 +57,14 @@ func (o *CmdOptions) RunClusters() error {
 	clusterCount := len(clist)
 	tmpClusters := clist
 	if clusterCount <= 0 {
-		msg += "There are no clusters in any projects. You can create a cluster with the 'create' command."
+		msg += "No clusters found."
 	} else if clusterCount > 0 {
 		sort.Sort(SortByClusterName(tmpClusters))
+		msg += fmt.Sprintf(linebreak+asterisk+"%-20s\t %-20s\t %-20s\t","name", "workers", "status")
 		for c, cluster := range tmpClusters {
 			if o.Name == "" || cluster.Name == o.Name {
 				if o.Output == "" {
-					msg += fmt.Sprintf(linebreak+asterisk+"%-14s\t %d\t %-30s\t %-32s\t %-32s\t %s\t  %s", cluster.Name,
-						cluster.WorkerCount, cluster.MasterURL, cluster.MasterWebURL, cluster.MasterWebRoute, cluster.Status, cluster.Ephemeral)
+					msg += fmt.Sprintf(	linebreak+asterisk+"%-20s\t %-20d\t %-20s\t", cluster.Name, cluster.WorkerCount,  cluster.Status)
 				} else if o.NoPods {
 					tmpClusters[c].Pods = nil
 				}

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -146,7 +146,7 @@ func CmdGet(f *osclientcmd.Factory, reader io.Reader, out io.Writer, extended bo
 	cmds.Flags().StringP("output", "o", "", "Output format. One of: json|yaml")
 	cmds.Flags().BoolVarP(&options.Verbose, "verbose", "v", options.Verbose, "Turn on verbose output\n\n")
 	cmds.Flags().BoolP("nopods", "", false, "Do not include pod list for cluster in yaml or json output")
-	cmds.Flags().BoolP("deprecated", "d", options.Deprecated, "deprecated")
+	cmds.Flags().BoolP("deprecated", "d", options.Deprecated, "This allows the user to see the old output from the get command")
 	if extended {
 		cmds.Flags().String("app", "", "Get the clusters associated with the app. The value may be the name of a pod or deployment (but not a deploymentconfig). Ignored if a name is specified.")
 	}

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -58,20 +58,22 @@ func (o *CmdOptions) RunClusters() error {
 	tmpClusters := clist
 	if clusterCount <= 0 {
 		msg += "No clusters found."
-	} else if clusterCount > 0 {
+	}else if clusterCount > 0 {
 		sort.Sort(SortByClusterName(tmpClusters))
-		msg += fmt.Sprintf(linebreak+asterisk+"%-20s\t %-20s\t %-20s\t","name", "workers", "status")
+		if !o.Deprecated {
+			msg += fmt.Sprintf(linebreak+asterisk+"%-20s\t %-20s\t %-20s\t", "name", "workers", "status")
+		}
 		for c, cluster := range tmpClusters {
 			if o.Name == "" || cluster.Name == o.Name {
-				if o.Output == "" {
-					msg += fmt.Sprintf(	linebreak+asterisk+"%-20s\t %-20d\t %-20s\t", cluster.Name, cluster.WorkerCount,  cluster.Status)
+				if o.Output == "" && !o.Deprecated {
+					msg += fmt.Sprintf(linebreak+asterisk+"%-20s\t %-20d\t %-20s\t", cluster.Name, cluster.WorkerCount, cluster.Status)
+				} else if o.Output == "" && o.Deprecated {
+					msg += fmt.Sprintf(linebreak+asterisk+"%-14s\t %d\t %-30s\t %-32s\t %-32s\t %s\t  %s", cluster.Name,
+						cluster.WorkerCount, cluster.MasterURL, cluster.MasterWebURL, cluster.MasterWebRoute, cluster.Status, cluster.Ephemeral)
 				} else if o.NoPods {
 					tmpClusters[c].Pods = nil
 				}
 			}
-		}
-		if o.Output != "" {
-			PrintOutput(o.Output, tmpClusters)
 		}
 	}
 	fmt.Println(msg)
@@ -140,8 +142,10 @@ func CmdGet(f *osclientcmd.Factory, reader io.Reader, out io.Writer, extended bo
 	cmds.Flags().StringP("output", "o", "", "Output format. One of: json|yaml")
 	cmds.Flags().BoolVarP(&options.Verbose, "verbose", "v", options.Verbose, "Turn on verbose output\n\n")
 	cmds.Flags().BoolP("nopods", "", false, "Do not include pod list for cluster in yaml or json output")
+	cmds.Flags().BoolP("deprecated", "d", options.Deprecated, "deprecated")
 	if extended {
 		cmds.Flags().String("app", "", "Get the clusters associated with the app. The value may be the name of a pod or deployment (but not a deploymentconfig). Ignored if a name is specified.")
 	}
 	return cmds
 }
+

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -58,9 +58,9 @@ func (o *CmdOptions) RunClusters() error {
 	tmpClusters := clist
 	if clusterCount <= 0 {
 		msg += "No clusters found."
-	}else if clusterCount > 0 {
+	} else if clusterCount > 0 {
 		sort.Sort(SortByClusterName(tmpClusters))
-		if !o.Deprecated {
+		if !o.Deprecated && o.Output == "" {
 			msg += fmt.Sprintf(linebreak+asterisk+"%-20s\t %-20s\t %-20s\t", "name", "workers", "status")
 		}
 		for c, cluster := range tmpClusters {
@@ -74,6 +74,10 @@ func (o *CmdOptions) RunClusters() error {
 					tmpClusters[c].Pods = nil
 				}
 			}
+		}
+
+		if o.Output != "" {
+			PrintOutput(o.Output, tmpClusters)
 		}
 	}
 	fmt.Println(msg)
@@ -148,4 +152,3 @@ func CmdGet(f *osclientcmd.Factory, reader io.Reader, out io.Writer, extended bo
 	}
 	return cmds
 }
-

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/create"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # name required
 os::cmd::expect_failure "_output/oshinko create"
@@ -100,17 +100,7 @@ os::cmd::expect_success "_output/oshinko delete klondike3"
 
 os::cmd::expect_failure_and_text "_output/oshinko create klondike4 --metrics=notgonnadoit" "must be 'true', 'false', 'jolokia', or 'prometheus'"
 
-# exposeui
-os::cmd::expect_success "_output/oshinko create charlie --exposeui=false"
-os::cmd::expect_success_and_text "_output/oshinko get charlie" "charlie.*<no route>"
-os::cmd::expect_success "_output/oshinko delete charlie"
-
-os::cmd::expect_success "_output/oshinko create charlie2 --exposeui=true"
-os::cmd::expect_success_and_text "_output/oshinko get charlie2" "charlie2-ui-route"
-os::cmd::expect_success "_output/oshinko delete charlie2"
-
 os::cmd::expect_success "_output/oshinko create charlie3"
-os::cmd::expect_success_and_text "_output/oshinko get charlie3" "charlie3-ui-route"
 os::cmd::expect_success "_output/oshinko delete charlie3"
 
 os::cmd::expect_failure_and_text "_output/oshinko create charlie4 --exposeui=notgonnadoit" "must be a boolean"

--- a/test/cmd/create.sh
+++ b/test/cmd/create.sh
@@ -100,9 +100,16 @@ os::cmd::expect_success "_output/oshinko delete klondike3"
 
 os::cmd::expect_failure_and_text "_output/oshinko create klondike4 --metrics=notgonnadoit" "must be 'true', 'false', 'jolokia', or 'prometheus'"
 
+#exposeui
+os::cmd::expect_success "_output/oshinko create charlie --exposeui=false"
+os::cmd::expect_success_and_text "_output/oshinko get -d charlie" "charlie.*<no route>"
+os::cmd::expect_success "_output/oshinko delete charlie"
+os::cmd::expect_success "_output/oshinko create charlie2 --exposeui=true"
+os::cmd::expect_success_and_text "_output/oshinko get -d charlie2" "charlie2-ui-route"
+os::cmd::expect_success "_output/oshinko delete charlie2"
 os::cmd::expect_success "_output/oshinko create charlie3"
+os::cmd::expect_success_and_text "_output/oshinko get -d charlie3" "charlie3-ui-route"
 os::cmd::expect_success "_output/oshinko delete charlie3"
-
 os::cmd::expect_failure_and_text "_output/oshinko create charlie4 --exposeui=notgonnadoit" "must be a boolean"
 
 # storedconfig

--- a/test/cmd/createeph.sh
+++ b/test/cmd/createeph.sh
@@ -59,6 +59,10 @@ os::cmd::expect_failure_and_text "_output/oshinko create_eph sally" "cluster 'sa
 os::cmd::expect_success "oc delete service sally-ui"
 os::cmd::expect_failure_and_text "_output/oshinko create_eph sally" "cluster 'sally' already exists \(incomplete\)"
 
+# exposeui
+os::cmd::expect_success "_output/oshinko create_eph charlie --exposeui=false"
+os::cmd::expect_success_and_text "_output/oshinko get -d charlie" "charlie.*<no route>"
+
 # storedconfig
 oc create configmap clusterconfig --from-literal=workercount=3 --from-literal=mastercount=0 
 os::cmd::expect_failure_and_text "_output/oshinko create_eph chicken --storedconfig=jack" "named config 'jack' does not exist"

--- a/test/cmd/createeph.sh
+++ b/test/cmd/createeph.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/createeph"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # name required
 os::cmd::expect_failure "_output/oshinko create_eph"
@@ -58,10 +58,6 @@ os::cmd::expect_failure_and_text "_output/oshinko create_eph sally" "cluster 'sa
 # create against incomplete clusters
 os::cmd::expect_success "oc delete service sally-ui"
 os::cmd::expect_failure_and_text "_output/oshinko create_eph sally" "cluster 'sally' already exists \(incomplete\)"
-
-# exposeui
-os::cmd::expect_success "_output/oshinko create_eph charlie --exposeui=false" 
-os::cmd::expect_success_and_text "_output/oshinko get charlie" "charlie.*<no route>"
 
 # storedconfig
 oc create configmap clusterconfig --from-literal=workercount=3 --from-literal=mastercount=0 

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/delete"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"

--- a/test/cmd/deleteeph.sh
+++ b/test/cmd/deleteeph.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/deleteeph"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -24,8 +24,7 @@ os::cmd::expect_success_and_text "_output/oshinko get" "abc"
 os::cmd::expect_success_and_text "_output/oshinko get" "def"
 
 # check for columns
-os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*Running"'
-
+os::cmd::expect_success '_output/oshinko-cli get -d abc | grep -e "^abc\s*[012]\s*spark://abc:7077\s*http://abc-ui:8080\s*abc-ui-route.*\s*Running\s*<shared>$"'
 # incomplete clusters	# incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"
 os::cmd::expect_success_and_text "_output/oshinko-cli get -d abc" "Incomplete"

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/get"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"
@@ -24,7 +24,7 @@ os::cmd::expect_success_and_text "_output/oshinko get" "abc"
 os::cmd::expect_success_and_text "_output/oshinko get" "def"
  
 # check for columns
-os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*spark://abc:7077\s*http://abc-ui:8080\s*abc-ui-route.*\s*Running\s*<shared>$"'
+os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*Running$"'
 
 # incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -24,21 +24,14 @@ os::cmd::expect_success_and_text "_output/oshinko get" "abc"
 os::cmd::expect_success_and_text "_output/oshinko get" "def"
  
 # check for columns
-os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*Running$"'
+os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*Running"'
 
 # incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"
 os::cmd::expect_success_and_text "_output/oshinko-cli get abc" "Incomplete"
-os::cmd::expect_success_and_text "_output/oshinko-cli get abc" "<missing>"
 
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get nothere" "no such cluster 'nothere'"
-
-# verbose
-os::cmd::expect_success_and_text "_output/oshinko get -v" "You have access to the following projects"
-os::cmd::expect_success_and_text "_output/oshinko get --verbose" "You have access to the following projects"
-os::cmd::expect_success_and_not_text "_output/oshinko get" "You have access to the following projects"
-os::cmd::expect_success_and_not_text "_output/oshinko get --verbose=false" "You have access to the following projects"
 
 # flags for ephemeral not valid
 os::cmd::expect_failure_and_text "_output/oshinko get --app=bill" "unknown flag"

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -22,13 +22,14 @@ os::cmd::expect_success_and_not_text "_output/oshinko get abc -o json --nopods" 
 # get all
 os::cmd::expect_success_and_text "_output/oshinko get" "abc"
 os::cmd::expect_success_and_text "_output/oshinko get" "def"
- 
+
 # check for columns
 os::cmd::expect_success '_output/oshinko-cli get abc | grep -e "^abc\s*[012]\s*Running"'
 
-# incomplete clusters
+# incomplete clusters	# incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"
-os::cmd::expect_success_and_text "_output/oshinko-cli get abc" "Incomplete"
+os::cmd::expect_success_and_text "_output/oshinko-cli get -d abc" "Incomplete"
+os::cmd::expect_success_and_text "_output/oshinko-cli get -d abc" "<missing>"
 
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get nothere" "no such cluster 'nothere'"

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -22,7 +22,7 @@ os::cmd::expect_success_and_not_text "_output/oshinko get_eph abc -o json --nopo
 # get all
 os::cmd::try_until_text "_output/oshinko get_eph" "abc"
 os::cmd::try_until_text "_output/oshinko get_eph" "def"
- 
+
 # check for columns
 os::cmd::expect_success '_output/oshinko-cli get_eph abc | grep -e "^abc\s*[012]\s*Running\s"'
 
@@ -32,7 +32,8 @@ os::cmd::expect_success_and_text "_output/oshinko create_eph -e effy --app=abc-m
 
 # incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"
-os::cmd::expect_success_and_text "_output/oshinko-cli get_eph abc" "Incomplete"
+os::cmd::expect_success_and_text "_output/oshinko-cli get_eph -d abc" "Incomplete"
+os::cmd::expect_success_and_text "_output/oshinko-cli get_eph -d abc" "<missing>"
 
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get_eph nothere" "no such cluster 'nothere'"

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -24,11 +24,12 @@ os::cmd::try_until_text "_output/oshinko get_eph" "abc"
 os::cmd::try_until_text "_output/oshinko get_eph" "def"
 
 # check for columns
-os::cmd::expect_success '_output/oshinko-cli get_eph abc | grep -e "^abc\s*[012]\s*Running\s"'
+os::cmd::expect_success '_output/oshinko-cli get_eph -d abc | grep -e "^abc\s*[012]\s*spark://abc:7077\s*http://abc-ui:8080\s*abc-ui-route.*\s*Running\s*<shared>$"'
 
 # app flag
 os::cmd::expect_failure_and_text "_output/oshinko get_eph --app=bill" "no cluster found for app 'bill'"
 os::cmd::expect_success_and_text "_output/oshinko create_eph -e effy --app=abc-m-1" 'ephemeral cluster "effy" created'
+os::cmd::expect_success_and_text "_output/oshinko get_eph -d --app=abc-m-1" "effy.*abc-m-1"
 
 # incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -5,7 +5,7 @@ trap os::test::junit::reconcile_output EXIT
 os::test::junit::declare_suite_start "cmd/geteph"
 
 # No clusters notice
-os::cmd::try_until_text "_output/oshinko get_eph" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get_eph" "No clusters found."
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"
@@ -24,27 +24,17 @@ os::cmd::try_until_text "_output/oshinko get_eph" "abc"
 os::cmd::try_until_text "_output/oshinko get_eph" "def"
  
 # check for columns
-os::cmd::expect_success '_output/oshinko-cli get_eph abc | grep -e "^abc\s*[012]\s*spark://abc:7077\s*http://abc-ui:8080\s*abc-ui-route.*\s*Running\s*<shared>$"'
+os::cmd::expect_success '_output/oshinko-cli get_eph abc | grep -e "^abc\s*[012]\s*Running\s"'
 
 # app flag
 os::cmd::expect_failure_and_text "_output/oshinko get_eph --app=bill" "no cluster found for app 'bill'"
 os::cmd::expect_success_and_text "_output/oshinko create_eph -e effy --app=abc-m-1" 'ephemeral cluster "effy" created'
-os::cmd::expect_success_and_text "_output/oshinko get_eph --app=abc-m-1" "effy.*abc-m-1"
-
-
 
 # incomplete clusters
 os::cmd::expect_success "oc delete service abc-ui"
 os::cmd::expect_success_and_text "_output/oshinko-cli get_eph abc" "Incomplete"
-os::cmd::expect_success_and_text "_output/oshinko-cli get_eph abc" "<missing>"
 
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get_eph nothere" "no such cluster 'nothere'"
-
-# verbose
-os::cmd::expect_success_and_text "_output/oshinko get_eph -v" "You have access to the following projects"
-os::cmd::expect_success_and_not_text "_output/oshinko get_eph" "You have access to the following projects"
-os::cmd::expect_success_and_not_text "_output/oshinko get" "You have access to the following projects"
-os::cmd::expect_success_and_not_text "_output/oshinko get --verbose=false" "You have access to the following projects"
 
 os::test::junit::declare_suite_end

--- a/test/cmd/scale.sh
+++ b/test/cmd/scale.sh
@@ -29,7 +29,7 @@ os::test::junit::declare_suite_start "cmd/scale"
 # General note -- at present, the master and worker counts in the included config object on get are "MasterCount" and "WorkerCount"
 # the master and worker counts in the outer cluster status are "masterCount" and "workerCount"
 
-os::cmd::try_until_text "_output/oshinko get" "There are no clusters in any projects. You can create a cluster with the 'create' command."
+os::cmd::try_until_text "_output/oshinko get" "No clusters found."
 
 # make a cluster to scale
 os::cmd::expect_success "_output/oshinko create abc"


### PR DESCRIPTION
When using `oshinko get` it will now return the header and results for: name, workers and status
![screen shot 2018-08-08 at 15 32 38](https://user-images.githubusercontent.com/22922596/43845179-4d9cd0ba-9b23-11e8-8187-4866a15a11be.png)
