### PR TITLE
Returns empty json/yaml for get

### DIFF
--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -82,6 +82,7 @@ func (o *CmdOptions) RunClusters() error {
 
 		if o.Output != "" {
 			PrintOutput(o.Output, tmpClusters)
+			return nil
 		}
 	}
 	fmt.Println(msg)

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -63,6 +63,11 @@ func (o *CmdOptions) RunClusters() error {
 	tmpClusters := clist
 
 	if clusterCount <= 0 {
+		if o.Output!="" {
+			msg+="[]"
+			fmt.Println(msg)
+			return nil
+		}
 		msg += "No clusters found."
 	} else if clusterCount > 0 {
 		sort.Sort(SortByClusterName(tmpClusters))

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -43,8 +43,11 @@ func (o *CmdOptions) RunClusters() error {
 
 	if o.Name != "" {
 		c, err := clusters.FindSingleCluster(o.Name, o.Project, o.Config)
-		if err != nil {
-			return err
+		//return empty json/yaml when no cluster found
+		if err!=nil  && o.Output!=""{
+			msg +="{}"
+			fmt.Println(msg)
+			return nil
 		}
 		clist = []clusters.SparkCluster{c}
 	} else {
@@ -56,6 +59,7 @@ func (o *CmdOptions) RunClusters() error {
 
 	clusterCount := len(clist)
 	tmpClusters := clist
+
 	if clusterCount <= 0 {
 		msg += "There are no clusters in any projects. You can create a cluster with the 'create' command."
 	} else if clusterCount > 0 {

--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -48,6 +48,8 @@ func (o *CmdOptions) RunClusters() error {
 			msg +="{}"
 			fmt.Println(msg)
 			return nil
+		} else if err!=nil && o.Output==""{
+			return err
 		}
 		clist = []clusters.SparkCluster{c}
 	} else {

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -33,6 +33,11 @@ os::cmd::expect_success_and_text "_output/oshinko-cli get -d abc" "<missing>"
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get nothere" "no such cluster 'nothere'"
 
+# check for no cluster but return json/yaml
+os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o json" "{}"
+os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o yaml" "{}"
+
+
 # flags for ephemeral not valid
 os::cmd::expect_failure_and_text "_output/oshinko get --app=bill" "unknown flag"
 

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -6,6 +6,10 @@ os::test::junit::declare_suite_start "cmd/get"
 
 # No clusters notice
 os::cmd::try_until_text "_output/oshinko get" "No clusters found."
+os::cmd::try_until_text "_output/oshinko get -o json" "\[\]"
+os::cmd::try_until_text "_output/oshinko get -o yaml" "\[\]"
+
+
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"
@@ -36,6 +40,7 @@ os::cmd::expect_failure_and_text "_output/oshinko get nothere" "no such cluster 
 # check for no cluster but return json/yaml
 os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o json" "{}"
 os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o yaml" "{}"
+
 
 
 # flags for ephemeral not valid

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -39,4 +39,9 @@ os::cmd::expect_success_and_text "_output/oshinko-cli get_eph -d abc" "<missing>
 # no such cluster
 os::cmd::expect_failure_and_text "_output/oshinko get_eph nothere" "no such cluster 'nothere'"
 
+# check for no cluster but return json/yaml
+os::cmd::expect_success_and_text "_output/oshinko-cli get_eph nemo -o json" "{}"
+os::cmd::expect_success_and_text "_output/oshinko-cli get_eph nemo -o yaml" "{}"
+
+
 os::test::junit::declare_suite_end

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -6,6 +6,8 @@ os::test::junit::declare_suite_start "cmd/geteph"
 
 # No clusters notice
 os::cmd::try_until_text "_output/oshinko get_eph" "No clusters found."
+os::cmd::try_until_text "_output/oshinko get_eph -o json" "\[\]"
+os::cmd::try_until_text "_output/oshinko get_eph -o yaml" "\[\]"
 
 # Create clusters so we can look at them
 os::cmd::expect_success "_output/oshinko create abc --workers=2"


### PR DESCRIPTION
If a get tries to get a cluster and there are none it will now return {} if -o json or -o yaml is used to make the output more standardised and what the user asked for rather than an error message. Fixes #45 