### PR TITLE
changed the output for a single cluster to return a json object

### DIFF
--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -70,6 +70,10 @@ func (o *CmdOptions) RunClusters() error {
 				}
 			}
 		}
+		if o.Output =="json" && clusterCount==1{
+			PrintSingleObject(tmpClusters[0])
+			return nil
+		}
 		if o.Output != "" {
 			PrintOutput(o.Output, tmpClusters)
 		}

--- a/pkg/cmd/cli/cmd/utils.go
+++ b/pkg/cmd/cli/cmd/utils.go
@@ -55,3 +55,21 @@ func PrintOutput(format string, object interface{}) error {
 	}
 	return nil
 }
+
+func PrintSingleObject(object interface{}) error{
+	var msg string
+	tmpCluster := object
+	y, err := json.Marshal(tmpCluster)
+
+	if err != nil {
+		return err
+	}
+	pmsg, err := prettyprint(y)
+	if err != nil {
+		return err
+	}
+	msg += string(pmsg)
+	fmt.Printf(msg)
+	return nil
+	}
+


### PR DESCRIPTION
_output/oshinko get test -o json used to return a json array it now just returns an object
solves issue #46 