### PR TITLE
Issue67

### DIFF
--- a/rest/restapi/server.go
+++ b/rest/restapi/server.go
@@ -218,12 +218,13 @@ func (s *Server) Listen() error {
 	if s.hasScheme(schemeHTTPS) { // exit early on missing params
 		if s.TLSCertificate == "" {
 			if s.TLSCertificateKey == "" {
-				s.Fatalf("the required flags `--tls-certificate` and `--tls-key` were not specified")
+				s.Fatalf("the required flags `--tls-certificate` and `--tls-key` were not specified " +
+					"or use --scheme=http to run without SSL")
 			}
-			s.Fatalf("the required flag `--tls-certificate` was not specified")
+			s.Fatalf("the required flag `--tls-certificate` was not specified or use --scheme=http to run without SSL")
 		}
 		if s.TLSCertificateKey == "" {
-			s.Fatalf("the required flag `--tls-key` was not specified")
+			s.Fatalf("the required flag `--tls-key` was not specified or use --scheme=http to run without SSL")
 		}
 
 		// Use http host if https host wasn't defined

--- a/rest/tools/common.sh
+++ b/rest/tools/common.sh
@@ -1,5 +1,16 @@
+#!/usr/bin/env bash
 
-TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')
+if [[ "$OSTYPE" == "darwin"* ]]; then
+   # Mac OSX
+   result=:$(brew ls coreutils)
+      if [ -z "$result" ]; then
+         'Error: coreutils is not installed.'
+         exit 1
+      fi
+   TOP_DIR=$(greadlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')
+else
+   TOP_DIR=$(readlink -f `dirname "$0"` | grep -o '.*/oshinko-cli')
+fi
 . $TOP_DIR/sparkimage.sh
 
 if [ -n "$OSHINKO_SERVER_TAG" ]


### PR DESCRIPTION
A message has been added to the error output when running the rest server without SSL that it can be ran that way by using --scheme=http. It also has the functionality to run the rest server and the cli test on macOS now. 