### PR TITLE
Return an error on get of specific cluster when -o flag is used

### DIFF
--- a/pkg/cmd/cli/cmd/get.go
+++ b/pkg/cmd/cli/cmd/get.go
@@ -43,12 +43,7 @@ func (o *CmdOptions) RunClusters() error {
 
 	if o.Name != "" {
 		c, err := clusters.FindSingleCluster(o.Name, o.Project, o.Config)
-		//return empty json/yaml when no cluster found
-		if err!=nil  && o.Output!=""{
-			msg +="{}"
-			fmt.Println(msg)
-			return nil
-		} else if err!=nil && o.Output==""{
+		if err!=nil {
 			return err
 		}
 		clist = []clusters.SparkCluster{c}

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -38,10 +38,8 @@ os::cmd::expect_success_and_text "_output/oshinko-cli get -d abc" "<missing>"
 os::cmd::expect_failure_and_text "_output/oshinko get nothere" "no such cluster 'nothere'"
 
 # check for no cluster but return json/yaml
-os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o json" "{}"
-os::cmd::expect_success_and_text "_output/oshinko-cli get nemo -o yaml" "{}"
-
-
+os::cmd::expect_failure_and_text "_output/oshinko-cli get nemo -o json" "no such cluster"
+os::cmd::expect_failure_and_text "_output/oshinko-cli get nemo -o yaml" "no such cluster"
 
 # flags for ephemeral not valid
 os::cmd::expect_failure_and_text "_output/oshinko get --app=bill" "unknown flag"

--- a/test/cmd/geteph.sh
+++ b/test/cmd/geteph.sh
@@ -42,8 +42,7 @@ os::cmd::expect_success_and_text "_output/oshinko-cli get_eph -d abc" "<missing>
 os::cmd::expect_failure_and_text "_output/oshinko get_eph nothere" "no such cluster 'nothere'"
 
 # check for no cluster but return json/yaml
-os::cmd::expect_success_and_text "_output/oshinko-cli get_eph nemo -o json" "{}"
-os::cmd::expect_success_and_text "_output/oshinko-cli get_eph nemo -o yaml" "{}"
-
+os::cmd::expect_failure_and_text "_output/oshinko-cli get_eph nemo -o json" "no such cluster"
+os::cmd::expect_failure_and_text "_output/oshinko-cli get_eph nemo -o yaml" "no such cluster"
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
This reverts part of the change made in pull request 125 to
return proper empty json/yaml for a cluster list on get. When
a specific cluster is named but is not present, an error should
still be returned