### PR TITLE
Stop race conditions in deleteeph.sh

### DIFF
--- a/test/cmd/deleteeph.sh
+++ b/test/cmd/deleteeph.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+TEMPLATE="$(dirname "${BASH_SOURCE}")/../test.json"
 trap os::test::junit::reconcile_output EXIT
 
 os::test::junit::declare_suite_start "cmd/deleteeph"
@@ -23,18 +24,19 @@ os::cmd::expect_failure_and_text "_output/oshinko delete_eph bob --app=sam-1" "B
 os::cmd::expect_failure_and_text "_output/oshinko delete_eph bob --app-status=completed" "Both --app and --app-status must be set"
 os::cmd::expect_failure_and_text "_output/oshinko delete_eph bob --app=sam-1 --app-status=wrong" "INVALID app-status value, only completed|terminated allowed"
 
-oc new-app hello-world
-os::cmd::try_until_success "oc get rc hello-world-1"
-os::cmd::expect_success_and_text "_output/oshinko create_eph -e cluster --app=hello-world-1" 'ephemeral cluster cluster'
+oc create -f $TEMPLATE
+oc new-app test-loop
+os::cmd::try_until_success "oc get rc test-loop-dc-1"
+os::cmd::expect_success_and_text "_output/oshinko create_eph -e cluster --app=test-loop-dc-1" 'ephemeral cluster cluster'
 
 # replica count won't work for hack/test-cmd, so only do this test when we're started from run.sh
 if [ "${USING_OPENSHIFT_INSTANCE:-false}" == true ]; then
     os::cmd::try_until_text 'oc get pod -l deploymentconfig=cluster-m --template="{{index .items 0 \"status\" \"phase\"}}"' "Running" $((5*minute))
     os::cmd::try_until_text 'oc get pod -l deploymentconfig=cluster-w --template="{{index .items 0 \"status\" \"phase\"}}"' "Running" $((5*minute))
-    os::cmd::expect_failure_and_text "_output/oshinko delete_eph cluster --app=hello-world-1 --app-status=terminated" "driver replica count > 0 \(or > 1 for completed app\)"
+    os::cmd::expect_failure_and_text "_output/oshinko delete_eph cluster --app=test-loop-dc-1 --app-status=terminated" "driver replica count > 0 \(or > 1 for completed app\)"
 fi
 os::cmd::expect_failure_and_text "_output/oshinko delete_eph cluster --app=someother --app-status=terminated" "cluster is not linked to app"
 
-os::cmd::expect_success "_output/oshinko delete_eph cluster --app=hello-world-1 --app-status=completed"
+os::cmd::expect_success "_output/oshinko delete_eph cluster --app=test-loop-dc-1 --app-status=completed"
 
 os::test::junit::declare_suite_end

--- a/test/test.json
+++ b/test/test.json
@@ -1,0 +1,101 @@
+{
+   "kind": "Template",
+   "apiVersion": "v1",
+   "metadata": {
+      "name": "test-loop"
+   },
+   "labels": {
+      "application": "test-loop"
+   },
+   "objects": [
+      {
+         "kind": "ImageStream",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "test-loop-is"
+         },
+         "spec": {
+            "dockerImageRepository": "test-loop",
+            "lookupPolicy": {
+                "local": true
+            },
+            "tags": [
+               {
+                  "name": "latest"
+               }
+            ]
+         }
+      },
+      {
+         "kind": "BuildConfig",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "test-loop-build"
+         },
+         "spec": {
+            "source": {
+              "type":"Dockerfile",
+              "dockerfile": "FROM centos:latest\nCMD while true ; do continue ; done"
+            },
+            "strategy": {
+               "type": "Docker",
+               "dockerStrategy": {
+                  "from": {
+                     "kind": "DockerImage",
+                     "name": "centos:latest",
+                     "forcePull": false
+                  }
+               }
+            },
+            "output": {
+               "to": {
+                  "kind": "ImageStreamTag",
+                  "name": "test-loop-is:latest"
+               }
+            },
+            "triggers": [
+              {
+                "type": "ConfigChange"
+              }
+            ]
+         }
+      },
+      {
+        "kind": "DeploymentConfig",
+        "apiVersion": "v1",
+        "metadata": {
+          "name":"test-loop-dc"
+        },
+        "spec":{
+          "replicas": 1,
+          "selector": {
+            "deploymentConfig": "test-loop-dc"
+          },
+          "strategy":{
+            "type": "Recreate"
+          },
+          "template":{
+            "metadata": {
+              "labels": {
+                "deploymentConfig": "test-loop-dc"
+              },
+              "name": "test-loop"
+            },
+            "spec":{
+              "containers":[
+                {
+                  "name": "test-loop",
+                  "image": "test-loop-is:latest",
+                  "imagePullPolicy": "Always"
+                }
+              ]
+            }
+          }
+        },
+
+        "strategy": {
+          "type": "rolling"
+        }
+      }
+   ]
+}


### PR DESCRIPTION
test/test.json added and test modified in deleteeph.sh
The template test-loop creates an image with an infinite loop thens build and deploys this to one pod. This is then assigned to the driver in the oshinko cluster and when delete is tried it does not work. Previously sometimes the image would have completed before the delete was called and therefore would delete the cluster is was an intermittent race condition.